### PR TITLE
Add optional per-medication stock tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Track medications, scheduled doses, streaks, and overdue alerts — entirely loc
 - **Sensors** for next dose time, last taken timestamp, streak (consecutive days taken), and doses taken today
 - **Binary sensors** for overdue detection (with configurable grace period) and due-soon alerts (within 60 minutes) for scheduled meds; availability tracking for PRN meds
 - **Button entities** to mark doses as taken or skipped — appear automatically on the device page
-- **Built-in notifications** — configure overdue, due soon, and taken confirmation alerts directly from the integration, with actionable notifications (Mark taken / Remind in 5 min) on iOS and Android
+- **Optional stock tracking** — record a current stock level per medication and it's automatically decremented each time a dose is taken, with a low-stock sensor and alert so you never run out
+- **Built-in notifications** — configure overdue, due soon, taken confirmation, and low stock alerts directly from the integration, with actionable notifications (Mark taken / Remind in 5 min) on iOS and Android
 - **Per-medication notification overrides** — enable or disable individual alert types per medication, overriding the global settings
-- **Services** to mark doses taken or skipped, and reset today's log
+- **Services** to mark doses taken or skipped, reset today's log, and adjust stock (e.g. after a refill)
 - **Full UI configuration** — add, edit, and remove medications via the Home Assistant UI (no YAML required)
 - **Optional Lovelace card** — a custom dashboard card showing all medications with status and action buttons
 - **Persistent storage** — survives restarts; today's log is pruned automatically at midnight

--- a/custom_components/medication_tracker/__init__.py
+++ b/custom_components/medication_tracker/__init__.py
@@ -12,11 +12,13 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    ATTR_AMOUNT,
     ATTR_MEDICATION_ID,
     ATTR_SCHEDULED_TIME,
     ATTR_TAKEN_AT,
     DOMAIN,
     PLATFORMS,
+    SERVICE_ADJUST_STOCK,
     SERVICE_MARK_SKIPPED,
     SERVICE_MARK_TAKEN,
     SERVICE_RESET_TODAY,
@@ -48,6 +50,14 @@ _MARK_TAKEN_SCHEMA = _SERVICE_BASE_SCHEMA.extend(
 _MARK_SKIPPED_SCHEMA = _SERVICE_BASE_SCHEMA.extend(
     {
         vol.Optional(ATTR_SCHEDULED_TIME): cv.string,
+    }
+)
+
+_ADJUST_STOCK_SCHEMA = _SERVICE_BASE_SCHEMA.extend(
+    {
+        vol.Required(ATTR_AMOUNT): vol.All(
+            vol.Coerce(float), vol.Range(min=-100000, max=100000)
+        ),
     }
 )
 
@@ -86,7 +96,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: MedicationTrackerConfig
         e for e in hass.config_entries.async_entries(DOMAIN) if e.entry_id != entry.entry_id
     ]
     if not remaining:
-        for svc in (SERVICE_MARK_TAKEN, SERVICE_MARK_SKIPPED, SERVICE_RESET_TODAY):
+        for svc in (
+            SERVICE_MARK_TAKEN,
+            SERVICE_MARK_SKIPPED,
+            SERVICE_RESET_TODAY,
+            SERVICE_ADJUST_STOCK,
+        ):
             if hass.services.has_service(DOMAIN, svc):
                 hass.services.async_remove(DOMAIN, svc)
 
@@ -145,6 +160,17 @@ def _register_services(hass: HomeAssistant, entry: MedicationTrackerConfigEntry)
                 f"Could not reset today's log for medication '{med_id}'."
             )
 
+    async def handle_adjust_stock(call: ServiceCall) -> None:
+        med_id: str = call.data[ATTR_MEDICATION_ID]
+        amount: float = call.data[ATTR_AMOUNT]
+        coordinator = _get_coordinator(hass, med_id)
+        success = await coordinator.async_adjust_stock(med_id, amount)
+        if not success:
+            raise ServiceValidationError(
+                f"Could not adjust stock for medication '{med_id}'. "
+                "Stock tracking may not be enabled for this medication."
+            )
+
     hass.services.async_register(
         DOMAIN, SERVICE_MARK_TAKEN, handle_mark_taken, schema=_MARK_TAKEN_SCHEMA
     )
@@ -153,4 +179,7 @@ def _register_services(hass: HomeAssistant, entry: MedicationTrackerConfigEntry)
     )
     hass.services.async_register(
         DOMAIN, SERVICE_RESET_TODAY, handle_reset_today, schema=_SERVICE_BASE_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_ADJUST_STOCK, handle_adjust_stock, schema=_ADJUST_STOCK_SCHEMA
     )

--- a/custom_components/medication_tracker/binary_sensor.py
+++ b/custom_components/medication_tracker/binary_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    ATTR_CURRENT_STOCK,
     ATTR_DOSE,
     ATTR_NEXT_DOSE,
     ATTR_NOTES,
@@ -23,6 +24,7 @@ from .const import (
     MED_TYPE_AS_NEEDED,
     SUFFIX_AVAILABLE,
     SUFFIX_DUE,
+    SUFFIX_LOW_STOCK,
     SUFFIX_OVERDUE,
 )
 from .coordinator import MedicationCoordinator
@@ -73,10 +75,12 @@ def _binary_sensors_for_med(
     if med and med.get("med_type") == MED_TYPE_AS_NEEDED:
         return [
             MedicationAvailableSensor(coordinator, entry_id, med_id),
+            MedicationLowStockSensor(coordinator, entry_id, med_id),
         ]
     return [
         MedicationOverdueSensor(coordinator, entry_id, med_id),
         MedicationDueSoonSensor(coordinator, entry_id, med_id),
+        MedicationLowStockSensor(coordinator, entry_id, med_id),
     ]
 
 
@@ -231,5 +235,42 @@ class MedicationAvailableSensor(MedicationBaseBinarySensor):
             "next_available": data.get("next_available"),
             "doses_taken_today": data.get("doses_taken_today", 0),
             "doses_taken_24h": data.get("doses_taken_24h", 0),
+            ATTR_DOSE: data.get(ATTR_DOSE, ""),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Low stock binary sensor
+# ---------------------------------------------------------------------------
+
+
+class MedicationLowStockSensor(MedicationBaseBinarySensor):
+    """Binary sensor: True when stock is at or below the low-stock threshold."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(
+        self, coordinator: MedicationCoordinator, entry_id: str, med_id: str
+    ) -> None:
+        super().__init__(coordinator, entry_id, med_id, SUFFIX_LOW_STOCK)
+
+    @property
+    def name(self) -> str:
+        return "Low Stock"
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self._state_data.get("is_low_stock", False))
+
+    @property
+    def icon(self) -> str:
+        return "mdi:package-variant-closed-remove" if self.is_on else "mdi:package-variant-closed"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        data = self._state_data
+        return {
+            ATTR_CURRENT_STOCK: data.get(ATTR_CURRENT_STOCK),
+            "stock_low_threshold": data.get("stock_low_threshold"),
             ATTR_DOSE: data.get(ATTR_DOSE, ""),
         }

--- a/custom_components/medication_tracker/config_flow.py
+++ b/custom_components/medication_tracker/config_flow.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_AS_NEEDED_MAX_PER_24H,
     CONF_AS_NEEDED_MAX_PER_DAY,
     CONF_AS_NEEDED_MIN_HOURS,
+    CONF_CURRENT_STOCK,
     CONF_MED_DAYS,
     CONF_MED_DOSE,
     CONF_MED_NAME,
@@ -27,12 +28,16 @@ from .const import (
     CONF_NOTIF_DUE_SOON_MESSAGE,
     CONF_NOTIF_DUE_SOON_TITLE,
     CONF_NOTIF_DUE_TITLE,
+    CONF_NOTIF_LOW_STOCK_ENABLED,
+    CONF_NOTIF_LOW_STOCK_MESSAGE,
+    CONF_NOTIF_LOW_STOCK_TITLE,
     CONF_NOTIF_OVERDUE_DELAY,
     CONF_NOTIF_OVERDUE_ENABLED,
     CONF_NOTIF_OVERDUE_MESSAGE,
     CONF_NOTIF_OVERDUE_TITLE,
     CONF_NOTIF_OVERRIDE_DUE,
     CONF_NOTIF_OVERRIDE_DUE_SOON,
+    CONF_NOTIF_OVERRIDE_LOW_STOCK,
     CONF_NOTIF_OVERRIDE_OVERDUE,
     CONF_NOTIF_OVERRIDE_TAKEN,
     CONF_NOTIF_OVERRIDES,
@@ -40,6 +45,9 @@ from .const import (
     CONF_NOTIF_TAKEN_MESSAGE,
     CONF_NOTIF_TAKEN_TITLE,
     CONF_NOTIF_TARGET,
+    CONF_STOCK_LOW_THRESHOLD,
+    CONF_STOCK_PER_DOSE,
+    CONF_STOCK_TRACKING_ENABLED,
     DEFAULT_AS_NEEDED_MAX_PER_24H,
     DEFAULT_AS_NEEDED_MAX_PER_DAY,
     DEFAULT_AS_NEEDED_MIN_HOURS,
@@ -47,10 +55,14 @@ from .const import (
     DEFAULT_DUE_SOON_MESSAGE,
     DEFAULT_DUE_SOON_TITLE,
     DEFAULT_DUE_TITLE,
+    DEFAULT_LOW_STOCK_MESSAGE,
+    DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
     DEFAULT_OVERDUE_DELAY,
     DEFAULT_OVERDUE_MESSAGE,
     DEFAULT_OVERDUE_TITLE,
+    DEFAULT_STOCK_LOW_THRESHOLD,
+    DEFAULT_STOCK_PER_DOSE,
     DEFAULT_TAKEN_MESSAGE,
     DEFAULT_TAKEN_TITLE,
     DOMAIN,
@@ -87,6 +99,60 @@ def _validate_days(days_raw: str) -> list[int]:
                 f"Invalid day '{part}'. Use mon/tue/wed/thu/fri/sat/sun or 0-6."
             )
     return sorted(set(result))
+
+
+def _stock_schema_fields(med: dict[str, Any] | None = None) -> dict[Any, Any]:
+    """Return the shared schema fields for optional per-medication stock tracking."""
+    med = med or {}
+    return {
+        vol.Optional(
+            CONF_STOCK_TRACKING_ENABLED,
+            default=med.get(CONF_STOCK_TRACKING_ENABLED, False),
+        ): bool,
+        vol.Optional(
+            CONF_CURRENT_STOCK,
+            default=med.get(CONF_CURRENT_STOCK) or 0,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Optional(
+            CONF_STOCK_PER_DOSE,
+            default=med.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE),
+        ): vol.All(vol.Coerce(float), vol.Range(min=0.01)),
+        vol.Optional(
+            CONF_STOCK_LOW_THRESHOLD,
+            default=med.get(CONF_STOCK_LOW_THRESHOLD, DEFAULT_STOCK_LOW_THRESHOLD),
+        ): vol.All(vol.Coerce(float), vol.Range(min=0)),
+    }
+
+
+def _stock_config_from_input(
+    user_input: dict[str, Any], existing_med: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Extract stock-tracking fields from options flow form input.
+
+    current_stock is only taken from the submitted form when tracking is being
+    newly enabled (adding a medication, or flipping tracking on for the first
+    time). Once tracking is already on, the form's snapshot of current_stock
+    (taken when the form was rendered) is stale relative to the coordinator's
+    live value — which can change via dose-taking or the adjust_stock service
+    while the form is open — so we preserve the live value instead of letting
+    an unrelated edit silently revert it. Adjusting stock thereafter goes
+    through the adjust_stock service.
+    """
+    existing_med = existing_med or {}
+    was_tracking = bool(existing_med.get(CONF_STOCK_TRACKING_ENABLED, False))
+    tracking_enabled = user_input.get(CONF_STOCK_TRACKING_ENABLED, False)
+    if was_tracking and tracking_enabled:
+        current_stock = existing_med.get(CONF_CURRENT_STOCK)
+    else:
+        current_stock = user_input.get(CONF_CURRENT_STOCK)
+    return {
+        CONF_STOCK_TRACKING_ENABLED: tracking_enabled,
+        CONF_CURRENT_STOCK: current_stock,
+        CONF_STOCK_PER_DOSE: user_input.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE),
+        CONF_STOCK_LOW_THRESHOLD: user_input.get(
+            CONF_STOCK_LOW_THRESHOLD, DEFAULT_STOCK_LOW_THRESHOLD
+        ),
+    }
 
 
 def _get_notify_services(hass: Any) -> dict[str, str]:
@@ -260,6 +326,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         "times": times,
                         "days": days,
                         "notes": base.get(CONF_MED_NOTES, ""),
+                        **_stock_config_from_input(user_input),
                     }
                 )
                 return await self.async_step_init()
@@ -270,6 +337,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 {
                     vol.Optional(CONF_MED_TIMES, default=""): str,
                     vol.Optional(CONF_MED_DAYS, default=""): str,
+                    **_stock_schema_fields(),
                 }
             ),
             errors=errors,
@@ -297,6 +365,7 @@ class MedicationOptionsFlow(OptionsFlow):
                     "as_needed_max_per_day": user_input.get(CONF_AS_NEEDED_MAX_PER_DAY, DEFAULT_AS_NEEDED_MAX_PER_DAY),
                     "as_needed_max_per_24h": user_input.get(CONF_AS_NEEDED_MAX_PER_24H, DEFAULT_AS_NEEDED_MAX_PER_24H),
                     "as_needed_min_hours": user_input.get(CONF_AS_NEEDED_MIN_HOURS, DEFAULT_AS_NEEDED_MIN_HOURS),
+                    **_stock_config_from_input(user_input),
                 }
             )
             return await self.async_step_init()
@@ -314,6 +383,7 @@ class MedicationOptionsFlow(OptionsFlow):
                     vol.Optional(CONF_AS_NEEDED_MIN_HOURS, default=DEFAULT_AS_NEEDED_MIN_HOURS): vol.All(
                         vol.Coerce(float), vol.Range(min=0.5, max=24)
                     ),
+                    **_stock_schema_fields(),
                 }
             ),
         )
@@ -394,6 +464,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         "times": times,
                         "days": days,
                         "notes": base.get(CONF_MED_NOTES, ""),
+                        **_stock_config_from_input(user_input, med),
                     },
                 )
                 return await self.async_step_init()
@@ -408,6 +479,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 {
                     vol.Optional(CONF_MED_TIMES, default=times_str): str,
                     vol.Optional(CONF_MED_DAYS, default=days_str): str,
+                    **_stock_schema_fields(med),
                 }
             ),
             errors=errors,
@@ -441,6 +513,7 @@ class MedicationOptionsFlow(OptionsFlow):
                     "as_needed_max_per_day": user_input.get(CONF_AS_NEEDED_MAX_PER_DAY, DEFAULT_AS_NEEDED_MAX_PER_DAY),
                     "as_needed_max_per_24h": user_input.get(CONF_AS_NEEDED_MAX_PER_24H, DEFAULT_AS_NEEDED_MAX_PER_24H),
                     "as_needed_min_hours": user_input.get(CONF_AS_NEEDED_MIN_HOURS, DEFAULT_AS_NEEDED_MIN_HOURS),
+                    **_stock_config_from_input(user_input, med),
                 },
             )
             return await self.async_step_init()
@@ -458,6 +531,7 @@ class MedicationOptionsFlow(OptionsFlow):
                     vol.Optional(CONF_AS_NEEDED_MIN_HOURS, default=med.get("as_needed_min_hours", DEFAULT_AS_NEEDED_MIN_HOURS)): vol.All(
                         vol.Coerce(float), vol.Range(min=0.5, max=24)
                     ),
+                    **_stock_schema_fields(med),
                 }
             ),
         )
@@ -530,6 +604,12 @@ class MedicationOptionsFlow(OptionsFlow):
                 )
                 return await self.async_step_notification_taken_message()
 
+            if action == "edit_low_stock_message":
+                await coordinator.async_update_notification_config(
+                    _notification_config_from_input(user_input, cfg)
+                )
+                return await self.async_step_notification_low_stock_message()
+
             if action == "per_medication":
                 await coordinator.async_update_notification_config(
                     _notification_config_from_input(user_input, cfg)
@@ -551,6 +631,7 @@ class MedicationOptionsFlow(OptionsFlow):
             "edit_overdue_message": "Edit overdue message template",
             "edit_due_soon_message": "Edit due soon message template",
             "edit_taken_message": "Edit taken confirmation message",
+            "edit_low_stock_message": "Edit low stock message template",
             "per_medication": "Per-medication overrides",
         }
 
@@ -581,6 +662,10 @@ class MedicationOptionsFlow(OptionsFlow):
                     vol.Optional(
                         CONF_NOTIF_TAKEN_ENABLED,
                         default=cfg.get(CONF_NOTIF_TAKEN_ENABLED, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_NOTIF_LOW_STOCK_ENABLED,
+                        default=cfg.get(CONF_NOTIF_LOW_STOCK_ENABLED, False),
                     ): bool,
                     vol.Required("action", default="save"): vol.In(action_labels),
                 }
@@ -744,6 +829,45 @@ class MedicationOptionsFlow(OptionsFlow):
         )
 
     # ------------------------------------------------------------------
+    # Notifications: low stock message template
+    # ------------------------------------------------------------------
+
+    async def async_step_notification_low_stock_message(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        coordinator = self._entry.runtime_data
+        cfg = coordinator.notification_config
+
+        if user_input is not None:
+            updated = {
+                **cfg,
+                CONF_NOTIF_LOW_STOCK_TITLE: user_input.get(
+                    CONF_NOTIF_LOW_STOCK_TITLE, DEFAULT_LOW_STOCK_TITLE
+                ),
+                CONF_NOTIF_LOW_STOCK_MESSAGE: user_input.get(
+                    CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE
+                ),
+            }
+            await coordinator.async_update_notification_config(updated)
+            return await self.async_step_notifications()
+
+        return self.async_show_form(
+            step_id="notification_low_stock_message",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_NOTIF_LOW_STOCK_TITLE,
+                        default=cfg.get(CONF_NOTIF_LOW_STOCK_TITLE, DEFAULT_LOW_STOCK_TITLE),
+                    ): str,
+                    vol.Optional(
+                        CONF_NOTIF_LOW_STOCK_MESSAGE,
+                        default=cfg.get(CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE),
+                    ): str,
+                }
+            ),
+        )
+
+    # ------------------------------------------------------------------
     # Notifications: pick medication for per-medication overrides
     # ------------------------------------------------------------------
 
@@ -793,11 +917,13 @@ class MedicationOptionsFlow(OptionsFlow):
             global_overdue = cfg.get(CONF_NOTIF_OVERDUE_ENABLED, False)
             global_due_soon = cfg.get(CONF_NOTIF_DUE_SOON_ENABLED, False)
             global_taken = cfg.get(CONF_NOTIF_TAKEN_ENABLED, False)
+            global_low_stock = cfg.get(CONF_NOTIF_LOW_STOCK_ENABLED, False)
 
             val_due = user_input.get(CONF_NOTIF_OVERRIDE_DUE)
             val_overdue = user_input.get(CONF_NOTIF_OVERRIDE_OVERDUE)
             val_due_soon = user_input.get(CONF_NOTIF_OVERRIDE_DUE_SOON)
             val_taken = user_input.get(CONF_NOTIF_OVERRIDE_TAKEN)
+            val_low_stock = user_input.get(CONF_NOTIF_OVERRIDE_LOW_STOCK)
 
             if val_due is not None and val_due != global_due:
                 overrides[CONF_NOTIF_OVERRIDE_DUE] = val_due
@@ -807,6 +933,8 @@ class MedicationOptionsFlow(OptionsFlow):
                 overrides[CONF_NOTIF_OVERRIDE_DUE_SOON] = val_due_soon
             if val_taken is not None and val_taken != global_taken:
                 overrides[CONF_NOTIF_OVERRIDE_TAKEN] = val_taken
+            if val_low_stock is not None and val_low_stock != global_low_stock:
+                overrides[CONF_NOTIF_OVERRIDE_LOW_STOCK] = val_low_stock
 
             await coordinator.async_update_med_notification_overrides(
                 self._override_med_id,  # type: ignore[arg-type]
@@ -818,6 +946,7 @@ class MedicationOptionsFlow(OptionsFlow):
         global_overdue = cfg.get(CONF_NOTIF_OVERDUE_ENABLED, False)
         global_due_soon = cfg.get(CONF_NOTIF_DUE_SOON_ENABLED, False)
         global_taken = cfg.get(CONF_NOTIF_TAKEN_ENABLED, False)
+        global_low_stock = cfg.get(CONF_NOTIF_LOW_STOCK_ENABLED, False)
 
         return self.async_show_form(
             step_id="notification_med_overrides",
@@ -838,6 +967,10 @@ class MedicationOptionsFlow(OptionsFlow):
                     vol.Optional(
                         CONF_NOTIF_OVERRIDE_TAKEN,
                         default=existing.get(CONF_NOTIF_OVERRIDE_TAKEN, global_taken),
+                    ): bool,
+                    vol.Optional(
+                        CONF_NOTIF_OVERRIDE_LOW_STOCK,
+                        default=existing.get(CONF_NOTIF_OVERRIDE_LOW_STOCK, global_low_stock),
                     ): bool,
                 }
             ),
@@ -874,5 +1007,8 @@ def _notification_config_from_input(
         ),
         CONF_NOTIF_TAKEN_ENABLED: user_input.get(
             CONF_NOTIF_TAKEN_ENABLED, existing.get(CONF_NOTIF_TAKEN_ENABLED, False)
+        ),
+        CONF_NOTIF_LOW_STOCK_ENABLED: user_input.get(
+            CONF_NOTIF_LOW_STOCK_ENABLED, existing.get(CONF_NOTIF_LOW_STOCK_ENABLED, False)
         ),
     }

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -24,11 +24,14 @@ SUFFIX_DUE = "due"
 SUFFIX_OVERDUE = "overdue"
 SUFFIX_MARK_TAKEN = "mark_taken"
 SUFFIX_MARK_SKIPPED = "mark_skipped"
+SUFFIX_STOCK = "stock"
+SUFFIX_LOW_STOCK = "low_stock"
 
 # Services
 SERVICE_MARK_TAKEN = "mark_taken"
 SERVICE_MARK_SKIPPED = "mark_skipped"
 SERVICE_RESET_TODAY = "reset_today"
+SERVICE_ADJUST_STOCK = "adjust_stock"
 
 # Attr keys used in service calls & state attributes
 ATTR_MEDICATION_ID = "medication_id"
@@ -43,6 +46,17 @@ ATTR_LAST_TAKEN = "last_taken"
 ATTR_NEXT_DOSE = "next_dose"
 ATTR_TAKEN_TODAY = "taken_today"
 ATTR_SKIPPED_TODAY = "skipped_today"
+ATTR_AMOUNT = "amount"
+ATTR_CURRENT_STOCK = "current_stock"
+
+# Stock tracking config keys (per medication, opt-in)
+CONF_STOCK_TRACKING_ENABLED = "stock_tracking_enabled"
+CONF_CURRENT_STOCK = "current_stock"
+CONF_STOCK_PER_DOSE = "stock_per_dose"
+CONF_STOCK_LOW_THRESHOLD = "stock_low_threshold"
+
+DEFAULT_STOCK_PER_DOSE = 1.0
+DEFAULT_STOCK_LOW_THRESHOLD = 5.0
 
 # How many minutes past a scheduled time before it's considered overdue
 OVERDUE_GRACE_MINUTES = 30
@@ -92,6 +106,9 @@ CONF_NOTIF_TAKEN_MESSAGE = "taken_message"
 CONF_NOTIF_DUE_ENABLED = "due_enabled"
 CONF_NOTIF_DUE_TITLE = "due_title"
 CONF_NOTIF_DUE_MESSAGE = "due_message"
+CONF_NOTIF_LOW_STOCK_ENABLED = "low_stock_enabled"
+CONF_NOTIF_LOW_STOCK_TITLE = "low_stock_title"
+CONF_NOTIF_LOW_STOCK_MESSAGE = "low_stock_message"
 
 # Per-medication override keys
 CONF_NOTIF_OVERRIDES = "notification_overrides"
@@ -99,6 +116,7 @@ CONF_NOTIF_OVERRIDE_OVERDUE = "override_overdue"
 CONF_NOTIF_OVERRIDE_DUE_SOON = "override_due_soon"
 CONF_NOTIF_OVERRIDE_TAKEN = "override_taken"
 CONF_NOTIF_OVERRIDE_DUE = "override_due"
+CONF_NOTIF_OVERRIDE_LOW_STOCK = "override_low_stock"
 
 # Default notify target
 DEFAULT_NOTIFY_TARGET = "notify.persistent_notification"
@@ -114,3 +132,5 @@ DEFAULT_TAKEN_TITLE = "{medication} taken"
 DEFAULT_TAKEN_MESSAGE = "{medication} ({dose}) has been marked as taken."
 DEFAULT_DUE_TITLE = "{medication} due now"
 DEFAULT_DUE_MESSAGE = "{medication} ({dose}) is due now."
+DEFAULT_LOW_STOCK_TITLE = "{medication} low on stock"
+DEFAULT_LOW_STOCK_MESSAGE = "{medication} ({dose}) has {stock} unit(s) left — time to restock."

--- a/custom_components/medication_tracker/coordinator.py
+++ b/custom_components/medication_tracker/coordinator.py
@@ -15,10 +15,16 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import homeassistant.util.dt as dt_util
 
 from .const import (
+    CONF_CURRENT_STOCK,
     CONF_NOTIFICATIONS,
+    CONF_STOCK_LOW_THRESHOLD,
+    CONF_STOCK_PER_DOSE,
+    CONF_STOCK_TRACKING_ENABLED,
     DEFAULT_AS_NEEDED_MAX_PER_24H,
     DEFAULT_AS_NEEDED_MAX_PER_DAY,
     DEFAULT_AS_NEEDED_MIN_HOURS,
+    DEFAULT_STOCK_LOW_THRESHOLD,
+    DEFAULT_STOCK_PER_DOSE,
     DOMAIN,
     DUE_SOON_MINUTES,
     MED_TYPE_AS_NEEDED,
@@ -159,6 +165,10 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "as_needed_max_per_day": config.get("as_needed_max_per_day", DEFAULT_AS_NEEDED_MAX_PER_DAY),
             "as_needed_max_per_24h": config.get("as_needed_max_per_24h", DEFAULT_AS_NEEDED_MAX_PER_24H),
             "as_needed_min_hours": config.get("as_needed_min_hours", DEFAULT_AS_NEEDED_MIN_HOURS),
+            CONF_STOCK_TRACKING_ENABLED: config.get(CONF_STOCK_TRACKING_ENABLED, False),
+            CONF_CURRENT_STOCK: config.get(CONF_CURRENT_STOCK),
+            CONF_STOCK_PER_DOSE: config.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE),
+            CONF_STOCK_LOW_THRESHOLD: config.get(CONF_STOCK_LOW_THRESHOLD, DEFAULT_STOCK_LOW_THRESHOLD),
         }
         self._medications.append(entry)
         await self._async_save()
@@ -179,6 +189,19 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "as_needed_max_per_day": config.get("as_needed_max_per_day", med.get("as_needed_max_per_day", DEFAULT_AS_NEEDED_MAX_PER_DAY)),
                     "as_needed_max_per_24h": config.get("as_needed_max_per_24h", med.get("as_needed_max_per_24h", DEFAULT_AS_NEEDED_MAX_PER_24H)),
                     "as_needed_min_hours": config.get("as_needed_min_hours", med.get("as_needed_min_hours", DEFAULT_AS_NEEDED_MIN_HOURS)),
+                    CONF_STOCK_TRACKING_ENABLED: config.get(
+                        CONF_STOCK_TRACKING_ENABLED, med.get(CONF_STOCK_TRACKING_ENABLED, False)
+                    ),
+                    CONF_CURRENT_STOCK: config.get(
+                        CONF_CURRENT_STOCK, med.get(CONF_CURRENT_STOCK)
+                    ),
+                    CONF_STOCK_PER_DOSE: config.get(
+                        CONF_STOCK_PER_DOSE, med.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE)
+                    ),
+                    CONF_STOCK_LOW_THRESHOLD: config.get(
+                        CONF_STOCK_LOW_THRESHOLD,
+                        med.get(CONF_STOCK_LOW_THRESHOLD, DEFAULT_STOCK_LOW_THRESHOLD),
+                    ),
                     # Preserve notification overrides
                     "notification_overrides": config.get(
                         "notification_overrides",
@@ -253,7 +276,8 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         taken_at: datetime | None = None,
         scheduled_time: str | None = None,
     ) -> bool:
-        if not self.get_medication(med_id):
+        med = self.get_medication(med_id)
+        if not med:
             return False
         now = taken_at or dt_util.now()
         entry = {
@@ -263,6 +287,15 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "action": "taken",
         }
         self._dose_log.setdefault(med_id, []).append(entry)
+
+        if med.get(CONF_STOCK_TRACKING_ENABLED) and med.get(CONF_CURRENT_STOCK) is not None:
+            per_dose = med.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE)
+            new_stock = max(0.0, round(med[CONF_CURRENT_STOCK] - per_dose, 2))
+            for i, m in enumerate(self._medications):
+                if m["id"] == med_id:
+                    self._medications[i] = {**m, CONF_CURRENT_STOCK: new_stock}
+                    break
+
         await self._async_save()
         await self.async_refresh()
 
@@ -302,6 +335,20 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._async_save()
         await self.async_refresh()
         return True
+
+    async def async_adjust_stock(self, med_id: str, amount: float) -> bool:
+        """Add to (or subtract from) a medication's current stock level."""
+        for i, med in enumerate(self._medications):
+            if med["id"] == med_id:
+                if not med.get(CONF_STOCK_TRACKING_ENABLED):
+                    return False
+                current = med.get(CONF_CURRENT_STOCK) or 0
+                new_stock = max(0.0, round(current + amount, 2))
+                self._medications[i] = {**med, CONF_CURRENT_STOCK: new_stock}
+                await self._async_save()
+                await self.async_refresh()
+                return True
+        return False
 
     # ------------------------------------------------------------------
     # Internal state calculation
@@ -396,6 +443,7 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
 
         streak = self._calculate_streak(med["id"], today)
+        stock_state = self._build_stock_state(med)
 
         return {
             "name": med["name"],
@@ -416,6 +464,7 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "next_dose_time": next_dose_time_str,
             "last_taken": last_taken,
             "streak": streak,
+            **stock_state,
         }
 
     def _build_as_needed_state(self, med: dict[str, Any], now: datetime) -> dict[str, Any]:
@@ -486,6 +535,7 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 next_available_dt = earliest_next
 
         streak = self._calculate_streak(med["id"], today)
+        stock_state = self._build_stock_state(med)
 
         return {
             "name": med["name"],
@@ -513,6 +563,24 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "is_due_soon": False,
             "next_dose": None,
             "next_dose_time": None,
+            **stock_state,
+        }
+
+    def _build_stock_state(self, med: dict[str, Any]) -> dict[str, Any]:
+        """Derive stock-tracking fields shared by scheduled and as-needed medications."""
+        tracking_enabled = bool(med.get(CONF_STOCK_TRACKING_ENABLED, False))
+        current_stock = med.get(CONF_CURRENT_STOCK)
+        stock_per_dose = med.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE)
+        stock_low_threshold = med.get(CONF_STOCK_LOW_THRESHOLD, DEFAULT_STOCK_LOW_THRESHOLD)
+        is_low_stock = (
+            tracking_enabled and current_stock is not None and current_stock <= stock_low_threshold
+        )
+        return {
+            "stock_tracking_enabled": tracking_enabled,
+            "current_stock": current_stock,
+            "stock_per_dose": stock_per_dose,
+            "stock_low_threshold": stock_low_threshold,
+            "is_low_stock": is_low_stock,
         }
 
     def _calculate_streak(self, med_id: str, today: date) -> int:

--- a/custom_components/medication_tracker/notify.py
+++ b/custom_components/medication_tracker/notify.py
@@ -18,12 +18,16 @@ from .const import (
     CONF_NOTIF_DUE_SOON_MESSAGE,
     CONF_NOTIF_DUE_SOON_TITLE,
     CONF_NOTIF_DUE_TITLE,
+    CONF_NOTIF_LOW_STOCK_ENABLED,
+    CONF_NOTIF_LOW_STOCK_MESSAGE,
+    CONF_NOTIF_LOW_STOCK_TITLE,
     CONF_NOTIF_OVERDUE_DELAY,
     CONF_NOTIF_OVERDUE_ENABLED,
     CONF_NOTIF_OVERDUE_MESSAGE,
     CONF_NOTIF_OVERDUE_TITLE,
     CONF_NOTIF_OVERRIDE_DUE,
     CONF_NOTIF_OVERRIDE_DUE_SOON,
+    CONF_NOTIF_OVERRIDE_LOW_STOCK,
     CONF_NOTIF_OVERRIDE_OVERDUE,
     CONF_NOTIF_OVERRIDE_TAKEN,
     CONF_NOTIF_OVERRIDES,
@@ -35,6 +39,8 @@ from .const import (
     DEFAULT_DUE_SOON_MESSAGE,
     DEFAULT_DUE_SOON_TITLE,
     DEFAULT_DUE_TITLE,
+    DEFAULT_LOW_STOCK_MESSAGE,
+    DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
     DEFAULT_OVERDUE_DELAY,
     DEFAULT_OVERDUE_MESSAGE,
@@ -100,6 +106,11 @@ class MedicationNotifier:
         self._coordinator = coordinator
         self._fired: set[str] = set()
         self._fired_date: date = date.today()
+        # Low stock is a persistent condition, not a daily occurrence like the
+        # other alert types, so its dedup key is tracked separately and only
+        # cleared when stock rises back above the threshold — not by the
+        # daily reset below, which would otherwise re-fire it every midnight.
+        self._low_stock_fired: set[str] = set()
         self._unsub_action: Any = None
         self._reminder_unsubs: list[Any] = []
         self._register_action_listener()
@@ -197,12 +208,14 @@ class MedicationNotifier:
         notif_config = self._coordinator.notification_config
 
         for med in self._coordinator.medications:
-            # PRN medications are excluded from all automatic notifications
-            if med.get("med_type") == MED_TYPE_AS_NEEDED:
-                continue
             med_id = med["id"]
             state = self._coordinator.get_med_state(med_id)
             overrides = med.get(CONF_NOTIF_OVERRIDES, {})
+            await self._check_low_stock(med, state, notif_config, overrides)
+
+            # Due/overdue/due-soon checks don't apply to PRN medications
+            if med.get("med_type") == MED_TYPE_AS_NEEDED:
+                continue
             await self._check_due(med, state, notif_config, overrides)
             await self._check_overdue(med, state, notif_config, overrides)
             await self._check_due_soon(med, state, notif_config, overrides)
@@ -385,6 +398,50 @@ class MedicationNotifier:
         )
         self._fired.add(fire_key)
 
+    async def _check_low_stock(
+        self,
+        med: dict[str, Any],
+        state: dict[str, Any],
+        notif_config: dict[str, Any],
+        overrides: dict[str, Any],
+    ) -> None:
+        med_id = med["id"]
+        if not state.get("is_low_stock"):
+            # Stock has been replenished — allow the alert to fire again if it drops low later
+            self._low_stock_fired.discard(med_id)
+            return
+
+        enabled = overrides.get(
+            CONF_NOTIF_OVERRIDE_LOW_STOCK,
+            notif_config.get(CONF_NOTIF_LOW_STOCK_ENABLED, False),
+        )
+        if not enabled:
+            _LOGGER.debug("Low stock notification disabled for %s", med["name"])
+            return
+
+        if med_id in self._low_stock_fired:
+            _LOGGER.debug("Low stock notification already fired for %s", med["name"])
+            return
+
+        _LOGGER.debug("Firing low stock notification for %s", med["name"])
+        title = notif_config.get(CONF_NOTIF_LOW_STOCK_TITLE, DEFAULT_LOW_STOCK_TITLE)
+        message = notif_config.get(CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE)
+        await self._send(
+            notif_config,
+            title,
+            message,
+            {
+                "medication": med["name"],
+                "dose": med.get("dose", ""),
+                "time": "",
+                "overdue_since": "",
+                "stock": _format_stock(state.get("current_stock")),
+            },
+            med_id=med["id"],
+            actionable=False,
+        )
+        self._low_stock_fired.add(med_id)
+
     # ------------------------------------------------------------------
     # Send
     # ------------------------------------------------------------------
@@ -456,3 +513,12 @@ def _format_time(iso_str: str) -> str:
         return dt.strftime("%H:%M")
     except ValueError:
         return iso_str
+
+
+def _format_stock(value: Any) -> str:
+    """Format a stock quantity for display, dropping a trailing .0."""
+    if value is None:
+        return ""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)

--- a/custom_components/medication_tracker/sensor.py
+++ b/custom_components/medication_tracker/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import homeassistant.util.dt as dt_util
 
 from .const import (
+    ATTR_CURRENT_STOCK,
     ATTR_DOSE,
     ATTR_LAST_TAKEN,
     ATTR_NEXT_DOSE,
@@ -32,6 +33,7 @@ from .const import (
     SUFFIX_LAST_TAKEN,
     SUFFIX_NEXT_AVAILABLE,
     SUFFIX_NEXT_DOSE,
+    SUFFIX_STOCK,
     SUFFIX_STREAK,
     SUFFIX_TAKEN_TODAY,
 )
@@ -89,12 +91,14 @@ def _sensors_for_med(
             MedicationLastTakenSensor(coordinator, entry_id, med_id),
             MedicationStreakSensor(coordinator, entry_id, med_id),
             MedicationTakenTodaySensor(coordinator, entry_id, med_id),
+            MedicationStockSensor(coordinator, entry_id, med_id),
         ]
     return [
         MedicationNextDoseSensor(coordinator, entry_id, med_id),
         MedicationLastTakenSensor(coordinator, entry_id, med_id),
         MedicationStreakSensor(coordinator, entry_id, med_id),
         MedicationTakenTodaySensor(coordinator, entry_id, med_id),
+        MedicationStockSensor(coordinator, entry_id, med_id),
     ]
 
 
@@ -327,4 +331,43 @@ class MedicationNextAvailableSensor(MedicationBaseSensor):
             "as_needed_min_hours": data.get("as_needed_min_hours"),
             ATTR_DOSE: data.get(ATTR_DOSE, ""),
             ATTR_NOTES: data.get(ATTR_NOTES, ""),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Stock sensor
+# ---------------------------------------------------------------------------
+
+
+class MedicationStockSensor(MedicationBaseSensor):
+    """Sensor showing the current stock level for a medication, when tracked."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:package-variant"
+    _attr_translation_key = "stock"
+
+    def __init__(
+        self, coordinator: MedicationCoordinator, entry_id: str, med_id: str
+    ) -> None:
+        super().__init__(coordinator, entry_id, med_id, SUFFIX_STOCK)
+
+    @property
+    def name(self) -> str:
+        return "Stock"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self._state_data
+        if not data.get("stock_tracking_enabled"):
+            return None
+        return data.get(ATTR_CURRENT_STOCK)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        data = self._state_data
+        return {
+            "stock_tracking_enabled": data.get("stock_tracking_enabled", False),
+            "stock_per_dose": data.get("stock_per_dose"),
+            "stock_low_threshold": data.get("stock_low_threshold"),
+            ATTR_DOSE: data.get(ATTR_DOSE, ""),
         }

--- a/custom_components/medication_tracker/services.yaml
+++ b/custom_components/medication_tracker/services.yaml
@@ -57,3 +57,29 @@ reset_today:
       required: true
       selector:
         text:
+
+adjust_stock:
+  name: Adjust medication stock
+  description: >
+    Add to or subtract from a medication's current stock level. Use a
+    positive amount when restocking, or a negative amount to correct a
+    miscount. Only works for medications with stock tracking enabled.
+  fields:
+    medication_id:
+      name: Medication ID
+      description: The unique ID of the medication.
+      required: true
+      selector:
+        text:
+    amount:
+      name: Amount
+      description: >
+        The quantity to add (positive) or remove (negative) from current
+        stock, e.g. 30 after a refill.
+      required: true
+      selector:
+        number:
+          min: -100000
+          max: 100000
+          step: 0.5
+          mode: box

--- a/custom_components/medication_tracker/strings.json
+++ b/custom_components/medication_tracker/strings.json
@@ -56,6 +56,7 @@
           "overdue_delay_minutes": "Overdue alert delay (minutes after grace period, 0 = immediate)",
           "due_soon_enabled": "Alert when a dose is due soon",
           "taken_enabled": "Confirm when a dose is marked taken",
+          "low_stock_enabled": "Alert when stock is running low",
           "action": "Next"
         }
       },
@@ -91,6 +92,14 @@
           "taken_message": "Notification message"
         }
       },
+      "notification_low_stock_message": {
+        "title": "Low stock message template",
+        "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.",
+        "data": {
+          "low_stock_title": "Notification title",
+          "low_stock_message": "Notification message"
+        }
+      },
       "notification_per_medication": {
         "title": "Per-medication overrides",
         "description": "Select a medication to configure individual notification settings.",
@@ -105,7 +114,8 @@
           "override_due": "Alert when due",
           "override_overdue": "Alert when overdue",
           "override_due_soon": "Alert when due soon",
-          "override_taken": "Confirm when taken"
+          "override_taken": "Confirm when taken",
+          "override_low_stock": "Alert when stock is low"
         }
       },
       "add_medication_scheduled": {
@@ -113,7 +123,11 @@
         "description": "Set the times and days this medication should be taken.",
         "data": {
           "times": "Scheduled times (HH:MM, comma-separated)",
-          "days": "Days (mon, tue, wed\u2026 or leave blank for every day)"
+          "days": "Days (mon, tue, wed… or leave blank for every day)",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       },
       "add_medication_as_needed": {
@@ -122,7 +136,11 @@
         "data": {
           "as_needed_max_per_day": "Max doses per day",
           "as_needed_max_per_24h": "Max doses per 24 hours (rolling)",
-          "as_needed_min_hours": "Minimum hours between doses"
+          "as_needed_min_hours": "Minimum hours between doses",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       },
       "edit_medication_scheduled": {
@@ -130,7 +148,11 @@
         "description": "Edit the times and days this medication should be taken.",
         "data": {
           "times": "Scheduled times (HH:MM, comma-separated)",
-          "days": "Days (mon, tue, wed\u2026 or leave blank for every day)"
+          "days": "Days (mon, tue, wed… or leave blank for every day)",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       },
       "edit_medication_as_needed": {
@@ -139,7 +161,11 @@
         "data": {
           "as_needed_max_per_day": "Max doses per day",
           "as_needed_max_per_24h": "Max doses per 24 hours (rolling)",
-          "as_needed_min_hours": "Minimum hours between doses"
+          "as_needed_min_hours": "Minimum hours between doses",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       }
     },

--- a/custom_components/medication_tracker/translations/en.json
+++ b/custom_components/medication_tracker/translations/en.json
@@ -51,11 +51,21 @@
         "description": "Configure when and how you are notified about medications.",
         "data": {
           "notify_target": "Notify service (e.g. notify.persistent_notification)",
+          "due_enabled": "Alert when a dose is due",
           "overdue_enabled": "Alert when a dose is overdue",
           "overdue_delay_minutes": "Overdue alert delay (minutes after grace period, 0 = immediate)",
           "due_soon_enabled": "Alert when a dose is due soon",
           "taken_enabled": "Confirm when a dose is marked taken",
+          "low_stock_enabled": "Alert when stock is running low",
           "action": "Next"
+        }
+      },
+      "notification_due_message": {
+        "title": "Due now message template",
+        "description": "Customise the message sent when a dose is due.",
+        "data": {
+          "due_title": "Notification title",
+          "due_message": "Notification message"
         }
       },
       "notification_overdue_message": {
@@ -82,6 +92,14 @@
           "taken_message": "Notification message"
         }
       },
+      "notification_low_stock_message": {
+        "title": "Low stock message template",
+        "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.",
+        "data": {
+          "low_stock_title": "Notification title",
+          "low_stock_message": "Notification message"
+        }
+      },
       "notification_per_medication": {
         "title": "Per-medication overrides",
         "description": "Select a medication to configure individual notification settings.",
@@ -93,9 +111,11 @@
         "title": "Overrides for {medication}",
         "description": "Toggle notifications for this medication. These override the global settings above.",
         "data": {
+          "override_due": "Alert when due",
           "override_overdue": "Alert when overdue",
           "override_due_soon": "Alert when due soon",
-          "override_taken": "Confirm when taken"
+          "override_taken": "Confirm when taken",
+          "override_low_stock": "Alert when stock is low"
         }
       },
       "add_medication_scheduled": {
@@ -103,7 +123,11 @@
         "description": "Set the times and days this medication should be taken.",
         "data": {
           "times": "Scheduled times (HH:MM, comma-separated)",
-          "days": "Days (mon, tue, wed\u2026 or leave blank for every day)"
+          "days": "Days (mon, tue, wed… or leave blank for every day)",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       },
       "add_medication_as_needed": {
@@ -112,7 +136,11 @@
         "data": {
           "as_needed_max_per_day": "Max doses per day",
           "as_needed_max_per_24h": "Max doses per 24 hours (rolling)",
-          "as_needed_min_hours": "Minimum hours between doses"
+          "as_needed_min_hours": "Minimum hours between doses",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       },
       "edit_medication_scheduled": {
@@ -120,7 +148,11 @@
         "description": "Edit the times and days this medication should be taken.",
         "data": {
           "times": "Scheduled times (HH:MM, comma-separated)",
-          "days": "Days (mon, tue, wed\u2026 or leave blank for every day)"
+          "days": "Days (mon, tue, wed… or leave blank for every day)",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       },
       "edit_medication_as_needed": {
@@ -129,7 +161,11 @@
         "data": {
           "as_needed_max_per_day": "Max doses per day",
           "as_needed_max_per_24h": "Max doses per 24 hours (rolling)",
-          "as_needed_min_hours": "Minimum hours between doses"
+          "as_needed_min_hours": "Minimum hours between doses",
+          "stock_tracking_enabled": "Track stock for this medication",
+          "current_stock": "Current stock",
+          "stock_per_dose": "Units used per dose",
+          "stock_low_threshold": "Alert when stock falls to or below"
         }
       }
     },


### PR DESCRIPTION
## Summary
Closes #2. Adds an opt-in "stock tracking" feature per medication:

- New per-medication fields (opt-in toggle): current stock, units used per dose, and a low-stock threshold — configurable when adding or editing a medication
- Stock automatically decrements by the configured units-per-dose whenever a dose is marked taken
- New `Stock` sensor and `Low Stock` binary sensor per medication (only meaningful when tracking is enabled for that medication)
- New `low_stock` notification type — global enable toggle, customizable title/message template (with a `{stock}` placeholder), and a per-medication override, consistent with the existing due/overdue/due-soon notifications
- New `medication_tracker.adjust_stock` service to add to or subtract from stock (e.g. after a refill), so restocking doesn't require re-opening the edit-medication form
- Editing a medication for unrelated reasons (e.g. changing dose times) no longer risks clobbering the live stock count with a stale form snapshot — once tracking is enabled, only the `adjust_stock` service (or a fresh toggle-on) changes the stored value
- README updated to document the new feature and service

## Test plan
- [x] `ruff check custom_components/` — passes
- [x] `flake8 custom_components/medication_tracker/ --max-line-length=120 --ignore=E501,W503` (Python 3.12, matching CI) — passes
- [x] `python3.12 -m py_compile` on all changed files — passes
- [x] `strings.json` / `translations/en.json` validated as valid JSON and kept in sync (also reconciled pre-existing drift between the two files)
- [ ] Manual verification in a running Home Assistant instance (not available in this environment) — recommend testing the add/edit medication flow, the adjust_stock service, and the low-stock notification before release


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_