### PR TITLE
Add a settable stock number entity and card top-up button

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ Stock tracking is off by default. To turn it on for a medication, click **Edit**
 
 Once enabled, stock decrements automatically every time a dose is marked taken, and the `stock` sensor / `low_stock` binary sensor start reporting real values instead of `unknown`.
 
-**Restocking:** once tracking is on, don't re-edit the medication to change the stock count — the edit form ignores the Current stock field after the first time (to avoid a stale form value silently overwriting stock that changed while the form was open). Instead use the `medication_tracker.adjust_stock` service (see [Services](#services)) to add stock after a refill or correct a miscount.
+**Restocking:** once tracking is on, don't re-edit the medication to change the stock count — the edit form ignores the Current stock field after the first time (to avoid a stale form value silently overwriting stock that changed while the form was open). Instead, top up stock one of these ways:
+
+- **Device page** — open the medication's device (Settings → Devices & Services → Medication Tracker → the medication), and set the **Stock** control under Controls directly to a new value
+- **Lovelace card** — click **Top up stock** on the medication's card, which opens the same Stock control
+- **Service** — call `medication_tracker.adjust_stock` (see [Services](#services)) to add or subtract an amount, handy for automations (e.g. after scanning a barcode)
 
 ### Notifications
 
@@ -149,6 +153,7 @@ After configuring global notification settings, choose **Per-medication override
 | `binary_sensor.<name>_due_soon` | `on` when the next dose is within 60 minutes |
 | `sensor.<name>_stock` | Current stock level (`unknown` unless [stock tracking](#stock-tracking-optional) is enabled) |
 | `binary_sensor.<name>_low_stock` | `on` when stock is at or below the low-stock threshold |
+| `number.<name>_stock` | Editable stock control — set directly to top up or correct stock; unavailable unless stock tracking is enabled |
 | `button.<name>_mark_taken` | Mark the current dose as taken |
 | `button.<name>_mark_skipped` | Mark the current dose as skipped |
 
@@ -163,6 +168,7 @@ After configuring global notification settings, choose **Per-medication override
 | `binary_sensor.<name>_available` | `on` when the medication is within all dose limits and can be taken |
 | `sensor.<name>_stock` | Current stock level (`unknown` unless [stock tracking](#stock-tracking-optional) is enabled) |
 | `binary_sensor.<name>_low_stock` | `on` when stock is at or below the low-stock threshold |
+| `number.<name>_stock` | Editable stock control — set directly to top up or correct stock; unavailable unless stock tracking is enabled |
 | `button.<name>_mark_taken` | Record a dose taken now |
 | `button.<name>_mark_skipped` | Mark a dose as skipped |
 
@@ -224,7 +230,7 @@ Clear all taken/skipped entries for today for a given medication.
 
 ### `medication_tracker.adjust_stock`
 
-Add to or subtract from a medication's current stock level — use this to restock after a refill or correct a miscount, rather than re-editing the medication. Only works for medications with [stock tracking](#stock-tracking-optional) enabled.
+Add to or subtract from a medication's current stock level — handy for automations (e.g. after scanning a barcode). For manual restocking, it's usually quicker to set the `number.<name>_stock` control directly from the device page or the **Top up stock** button on the Lovelace card (see [Stock tracking](#stock-tracking-optional)). Only works for medications with stock tracking enabled.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -235,7 +241,7 @@ Add to or subtract from a medication's current stock level — use this to resto
 
 ## Optional: Lovelace Dashboard Card
 
-A custom card is available that shows all your medications in one place, including status, next dose time, last taken, streak, doses taken today, and Mark taken / Skip dose buttons.
+A custom card is available that shows all your medications in one place, including status, next dose time, last taken, streak, doses taken today, and Mark taken / Skip dose buttons. Medications with stock tracking enabled also show the current stock level and a **Top up stock** button.
 
 ![Medication Tracker Lovelace Card](docs/lovelace-card.png)
 

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -1,7 +1,7 @@
 """Constants for the Medication Tracker integration."""
 
 DOMAIN = "medication_tracker"
-PLATFORMS = ["sensor", "binary_sensor", "button"]
+PLATFORMS = ["sensor", "binary_sensor", "button", "number"]
 
 # Config keys
 CONF_MEDICATIONS = "medications"
@@ -26,6 +26,7 @@ SUFFIX_MARK_TAKEN = "mark_taken"
 SUFFIX_MARK_SKIPPED = "mark_skipped"
 SUFFIX_STOCK = "stock"
 SUFFIX_LOW_STOCK = "low_stock"
+SUFFIX_STOCK_NUMBER = "stock_number"
 
 # Services
 SERVICE_MARK_TAKEN = "mark_taken"

--- a/custom_components/medication_tracker/coordinator.py
+++ b/custom_components/medication_tracker/coordinator.py
@@ -338,12 +338,23 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_adjust_stock(self, med_id: str, amount: float) -> bool:
         """Add to (or subtract from) a medication's current stock level."""
+        med = self.get_medication(med_id)
+        if not med or not med.get(CONF_STOCK_TRACKING_ENABLED):
+            return False
+        current = med.get(CONF_CURRENT_STOCK) or 0
+        return await self._async_write_stock(med_id, current + amount)
+
+    async def async_set_stock(self, med_id: str, value: float) -> bool:
+        """Set a medication's current stock to an absolute value."""
+        med = self.get_medication(med_id)
+        if not med or not med.get(CONF_STOCK_TRACKING_ENABLED):
+            return False
+        return await self._async_write_stock(med_id, value)
+
+    async def _async_write_stock(self, med_id: str, new_value: float) -> bool:
         for i, med in enumerate(self._medications):
             if med["id"] == med_id:
-                if not med.get(CONF_STOCK_TRACKING_ENABLED):
-                    return False
-                current = med.get(CONF_CURRENT_STOCK) or 0
-                new_stock = max(0.0, round(current + amount, 2))
+                new_stock = max(0.0, round(new_value, 2))
                 self._medications[i] = {**med, CONF_CURRENT_STOCK: new_stock}
                 await self._async_save()
                 await self.async_refresh()

--- a/custom_components/medication_tracker/number.py
+++ b/custom_components/medication_tracker/number.py
@@ -1,0 +1,126 @@
+"""Number platform for Medication Tracker."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    ATTR_CURRENT_STOCK,
+    DOMAIN,
+    SUFFIX_STOCK_NUMBER,
+)
+from .coordinator import MedicationCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up number entities for each medication."""
+    coordinator: MedicationCoordinator = entry.runtime_data
+    entities: list[NumberEntity] = []
+    for med in coordinator.medications:
+        entities += _numbers_for_med(coordinator, entry.entry_id, med["id"])
+    async_add_entities(entities)
+
+    # Dynamic addition when medications are added via options flow
+    entry.async_on_unload(
+        coordinator.async_add_listener(
+            lambda: _async_update_entities(hass, coordinator, entry, async_add_entities)
+        )
+    )
+
+
+_tracked_med_ids: dict[str, set[str]] = {}
+
+
+def _async_update_entities(
+    hass: HomeAssistant,
+    coordinator: MedicationCoordinator,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add number entities for any newly added medications."""
+    known = _tracked_med_ids.setdefault(entry.entry_id, set())
+    new_entities: list[NumberEntity] = []
+    for med in coordinator.medications:
+        if med["id"] not in known:
+            new_entities += _numbers_for_med(coordinator, entry.entry_id, med["id"])
+    if new_entities:
+        async_add_entities(new_entities)
+
+
+def _numbers_for_med(
+    coordinator: MedicationCoordinator, entry_id: str, med_id: str
+) -> list[NumberEntity]:
+    """Return all number entities for a single medication."""
+    _tracked_med_ids.setdefault(entry_id, set()).add(med_id)
+    return [MedicationStockNumber(coordinator, entry_id, med_id)]
+
+
+# ---------------------------------------------------------------------------
+# Stock number — directly settable, so stock can be topped up without
+# re-opening the edit-medication form or calling a service by hand.
+# ---------------------------------------------------------------------------
+
+
+class MedicationStockNumber(CoordinatorEntity[MedicationCoordinator], NumberEntity):
+    """Editable control for a medication's current stock level."""
+
+    _attr_has_entity_name = True
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100000
+    _attr_native_step = 0.5
+    _attr_mode = NumberMode.BOX
+    _attr_icon = "mdi:package-variant"
+
+    def __init__(
+        self, coordinator: MedicationCoordinator, entry_id: str, med_id: str
+    ) -> None:
+        super().__init__(coordinator)
+        self._med_id = med_id
+        self._entry_id = entry_id
+        self._attr_unique_id = f"{entry_id}_{med_id}_{SUFFIX_STOCK_NUMBER}"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, f"{entry_id}_{med_id}")},
+            name=self._med_name,
+            manufacturer="Medication Tracker",
+        )
+
+    @property
+    def _med_name(self) -> str:
+        med = self.coordinator.get_medication(self._med_id)
+        return med["name"] if med else "Unknown"
+
+    @property
+    def _state_data(self) -> dict[str, Any]:
+        return self.coordinator.get_med_state(self._med_id)
+
+    @property
+    def name(self) -> str:
+        return "Stock"
+
+    @property
+    def available(self) -> bool:
+        return (
+            self.coordinator.last_update_success
+            and bool(self.coordinator.get_medication(self._med_id))
+            and bool(self._state_data.get("stock_tracking_enabled"))
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        return self._state_data.get(ATTR_CURRENT_STOCK)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the stock to an absolute value — e.g. after a refill."""
+        await self.coordinator.async_set_stock(self._med_id, value)

--- a/medication-tracker-card.js
+++ b/medication-tracker-card.js
@@ -43,6 +43,9 @@ class MedicationTrackerCard extends HTMLElement {
         taken_today: get("sensor", "taken_today"),
         overdue: get("binary_sensor", "overdue"),
         due_soon: get("binary_sensor", "due_soon"),
+        stock: get("sensor", "stock"),
+        low_stock: get("binary_sensor", "low_stock"),
+        stock_number: get("number", "stock"),
         btn_taken: get("button", "mark_taken"),
         btn_skipped: get("button", "mark_skipped"),
       };
@@ -61,6 +64,9 @@ class MedicationTrackerCard extends HTMLElement {
         last_taken: get("sensor", "last_taken"),
         streak: get("sensor", "streak"),
         taken_today: get("sensor", "taken_today"),
+        stock: get("sensor", "stock"),
+        low_stock: get("binary_sensor", "low_stock"),
+        stock_number: get("number", "stock"),
         btn_taken: get("button", "mark_taken"),
         btn_skipped: get("button", "mark_skipped"),
       };
@@ -82,13 +88,36 @@ class MedicationTrackerCard extends HTMLElement {
     } catch { return "—"; }
   }
 
+  _hasStock(med) {
+    const s = med.stock?.state;
+    return !!(med.stock_number && s && s !== "unknown" && s !== "unavailable");
+  }
+
+  _renderStockStat(med) {
+    if (!this._hasStock(med)) return "";
+    const isLow = med.low_stock?.state === "on";
+    return `
+      <div class="stat">
+        <span class="stat-label">Stock</span>
+        <span class="stat-value${isLow ? " stat-low-stock" : ""}">${med.stock.state}${isLow ? " ⚠️" : ""}</span>
+      </div>
+    `;
+  }
+
+  _renderTopUpButton(med) {
+    if (!this._hasStock(med)) return "";
+    return `<button class="btn btn-topup" data-entity="number.${med.base}_stock">Top up stock</button>`;
+  }
+
   _renderScheduledMed(med) {
     const isOverdue = med.overdue?.state === "on";
     const isDueSoon = med.due_soon?.state === "on";
+    const isLowStock = med.low_stock?.state === "on";
     let rowClass = "med-row";
     let badge = `<span class="status-badge badge-ok">On track</span>`;
     if (isOverdue) { rowClass += " overdue"; badge = `<span class="status-badge badge-overdue">Overdue</span>`; }
     else if (isDueSoon) { rowClass += " due-soon"; badge = `<span class="status-badge badge-due-soon">Due soon</span>`; }
+    if (isLowStock) badge += `<span class="status-badge badge-low-stock">Low stock</span>`;
 
     const nextDose = this._formatRelative(med.next_dose?.state);
     const lastTaken = this._formatRelative(med.last_taken?.state);
@@ -106,10 +135,12 @@ class MedicationTrackerCard extends HTMLElement {
           <div class="stat"><span class="stat-label">Last taken</span><span class="stat-value">${lastTaken}</span></div>
           <div class="stat"><span class="stat-label">Streak</span><span class="stat-value">${streak} day${streak === "1" ? "" : "s"}</span></div>
           <div class="stat"><span class="stat-label">Taken today</span><span class="stat-value">${takenToday} / ${scheduledToday}</span></div>
+          ${this._renderStockStat(med)}
         </div>
         <div class="actions">
           ${btnTakenId ? `<button class="btn btn-taken" data-entity="${btnTakenId}">Mark taken</button>` : ""}
           ${btnSkippedId ? `<button class="btn btn-skipped" data-entity="${btnSkippedId}">Skip dose</button>` : ""}
+          ${this._renderTopUpButton(med)}
         </div>
       </div>
     `;
@@ -122,6 +153,7 @@ class MedicationTrackerCard extends HTMLElement {
     const takenToday = med.taken_today?.state ?? "0";
     const lastTaken = this._formatRelative(med.last_taken?.state);
     const btnTakenId = med.btn_taken ? `button.${med.base}_mark_taken` : null;
+    const isLowStock = med.low_stock?.state === "on";
 
     let rowClass = "med-row";
     let badge;
@@ -140,6 +172,7 @@ class MedicationTrackerCard extends HTMLElement {
       badge = `<span class="status-badge badge-waiting">Available ${countdown}</span>`;
       availabilityInfo = `Next available ${countdown}`;
     }
+    if (isLowStock) badge += `<span class="status-badge badge-low-stock">Low stock</span>`;
 
     return `
       <div class="${rowClass}">
@@ -148,9 +181,11 @@ class MedicationTrackerCard extends HTMLElement {
           <div class="stat"><span class="stat-label">Availability</span><span class="stat-value">${availabilityInfo}</span></div>
           <div class="stat"><span class="stat-label">Last taken</span><span class="stat-value">${lastTaken}</span></div>
           <div class="stat"><span class="stat-label">Taken today</span><span class="stat-value">${takenToday} / ${maxPerDay}</span></div>
+          ${this._renderStockStat(med)}
         </div>
         <div class="actions">
           ${btnTakenId ? `<button class="btn btn-taken${isAvailable ? "" : " btn-disabled"}" data-entity="${btnTakenId}" ${isAvailable ? "" : "disabled"}>Mark taken</button>` : ""}
+          ${this._renderTopUpButton(med)}
         </div>
       </div>
     `;
@@ -174,6 +209,17 @@ class MedicationTrackerCard extends HTMLElement {
   async _callButton(entityId) {
     if (!this._hass) return;
     await this._hass.callService("button", "press", { entity_id: entityId });
+  }
+
+  _openMoreInfo(entityId) {
+    // Opens HA's built-in more-info dialog for the stock number entity, which
+    // has its own +/- controls for topping up or correcting stock — no need
+    // to hand-roll an amount prompt here.
+    this.dispatchEvent(new CustomEvent("hass-more-info", {
+      bubbles: true,
+      composed: true,
+      detail: { entityId },
+    }));
   }
 
   _render() {
@@ -208,6 +254,9 @@ class MedicationTrackerCard extends HTMLElement {
       .badge-waiting { background: var(--warning-color, #ffa600); color: white; }
       .badge-limit { background: var(--error-color, #db4437); color: white; }
       .btn-disabled { opacity: 0.4; cursor: not-allowed; }
+      .badge-low-stock { background: var(--warning-color, #ffa600); color: white; }
+      .stat-low-stock { color: var(--warning-color, #ffa600); }
+      .btn-topup { background: var(--secondary-background-color, #f5f5f5); color: var(--primary-text-color); border: 1px solid var(--divider-color, #e0e0e0); flex: 0 0 auto; padding: 7px 12px; }
     `;
 
     let rows;
@@ -231,7 +280,11 @@ class MedicationTrackerCard extends HTMLElement {
     `;
 
     this.shadowRoot.querySelectorAll(".btn[data-entity]").forEach(btn => {
-      btn.addEventListener("click", () => this._callButton(btn.dataset.entity));
+      if (btn.classList.contains("btn-topup")) {
+        btn.addEventListener("click", () => this._openMoreInfo(btn.dataset.entity));
+      } else {
+        btn.addEventListener("click", () => this._callButton(btn.dataset.entity));
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
Follow-up to the stock tracking feature (#4) — topping up stock currently requires either re-editing the medication (which the edit form intentionally ignores once tracking is on, per #4) or calling `adjust_stock` from Developer Tools, both a bit clunky for a routine refill.

- New `number.<name>_stock` entity, directly settable (e.g. from the device page's Controls section, as shown in the screenshot on the issue) — backed by a new `MedicationCoordinator.async_set_stock` method
- Unavailable unless stock tracking is enabled for that medication, consistent with the existing stock sensor/binary sensor
- `medication_tracker-card.js` now shows the current stock (with a low-stock warning badge/color) and a **Top up stock** button per medication, which opens the number entity's built-in more-info dialog (HA's native `+`/`-`/box controls) rather than a custom prompt
- `async_adjust_stock` and the new `async_set_stock` now share a small private `_async_write_stock` helper instead of duplicating the same find/clamp/save/refresh logic
- README updated: new `number.<name>_stock` entity documented, restocking guidance updated to lead with the device-page/card controls (service call kept as the automation-friendly option)

## Test plan
- [x] `ruff check custom_components/` — passes
- [x] `flake8 custom_components/medication_tracker/ --max-line-length=120 --ignore=E501,W503` (Python 3.12, matching CI) — passes
- [x] `python3.12 -m py_compile` on all changed/new files — passes
- [x] `node --check medication-tracker-card.js` — valid syntax
- [x] Manual verification in a running Home Assistant instance (not available in this environment) — recommend confirming the Stock control appears/behaves correctly on the device page and that the card's Top up button opens the right entity's more-info dialog


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_