### PR TITLE
docs: fix Lovelace card path and clarify it isn't HACS-managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,15 +245,19 @@ A custom card is available that shows all your medications in one place, includi
 
 ![Medication Tracker Lovelace Card](docs/lovelace-card.png)
 
-> **Note:** This card is optional and requires a one-time manual step. It is not installed automatically by HACS.
+> **Note:** This card is optional and requires a manual step, and unlike the integration itself it is **not** kept up to date by HACS — HACS only manages `custom_components/medication_tracker/`. Whenever this file changes, you need to re-copy it yourself (see below).
 
 ### Installation
 
-1. Copy `www/medication-tracker-card.js` from this directory into your Home Assistant `www` folder (i.e. `config/www/medication-tracker-card.js`)
+1. Copy `medication-tracker-card.js` from the root of this repository into your Home Assistant `www` folder (i.e. `config/www/medication-tracker-card.js`) — via the File editor/Studio Code Server add-on, Samba, or `curl -o config/www/medication-tracker-card.js https://raw.githubusercontent.com/calebgab/medication_tracker/main/medication-tracker-card.js` from the Terminal add-on
 2. Go to **Settings → Dashboards → Resources**
 3. Click **Add resource**
 4. Set URL to `/local/medication-tracker-card.js` and type to **JavaScript module**
 5. Click **Create** then reload the page
+
+### Updating the card
+
+Because HACS doesn't manage this file, updating the integration via HACS does **not** update the card. After an update that touches `medication-tracker-card.js` (check the [releases](https://github.com/calebgab/medication_tracker/releases) or recent commits), repeat step 1 above to overwrite your local copy, then hard-refresh your browser (`Ctrl+Shift+R` / `Cmd+Shift+R`) — the frontend caches this file aggressively, so a HA restart alone often isn't enough.
 
 ### Adding the card to a dashboard
 


### PR DESCRIPTION
## Summary
Root cause of a user report that the new "Top up stock" card button (#6) wasn't appearing: the Lovelace card isn't part of the HACS-managed integration bundle (HACS only tracks `custom_components/medication_tracker/`), so redownloading/restarting never updates the user's `config/www/medication-tracker-card.js` copy. On top of that, the install instructions pointed at the wrong path (`www/medication-tracker-card.js`, which doesn't exist — the file lives at the repo root).

- Fixes the copy path in the install steps
- Adds an explicit "Updating the card" section explaining HACS doesn't manage this file and that a manual re-copy + hard browser refresh is required after any change to it

## Test plan
- [x] Manual read-through against the actual repo file layout


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_