### PR TITLE
Add per-alert-type sound toggle for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Notifications on iOS and Android include **Mark taken** and **Remind in 5 min** 
 
 The low stock alert fires once when stock crosses the threshold and won't repeat until you restock above it (via the `adjust_stock` service) and it drops low again.
 
-After the global settings, you can also customise the notification title and message templates for each alert type.
+After the global settings, you can also customise the notification title and message templates for each alert type — and, alongside each template, a **Play a sound** toggle for that alert type (on by default, matching prior behaviour).
+
+**Sound is iOS-only.** Turning it off mutes that alert type's push notification on iOS. Android notification sound is controlled by the OS's notification channels, not the app payload, so this toggle has no effect there — configure sound per-channel in your device's own notification settings (Settings → Apps → Home Assistant → Notifications) instead.
 
 #### Per-medication notification overrides
 

--- a/custom_components/medication_tracker/config_flow.py
+++ b/custom_components/medication_tracker/config_flow.py
@@ -26,14 +26,18 @@ from .const import (
     CONF_NOTIF_DUE_MESSAGE,
     CONF_NOTIF_DUE_SOON_ENABLED,
     CONF_NOTIF_DUE_SOON_MESSAGE,
+    CONF_NOTIF_DUE_SOON_SOUND_ENABLED,
     CONF_NOTIF_DUE_SOON_TITLE,
+    CONF_NOTIF_DUE_SOUND_ENABLED,
     CONF_NOTIF_DUE_TITLE,
     CONF_NOTIF_LOW_STOCK_ENABLED,
     CONF_NOTIF_LOW_STOCK_MESSAGE,
+    CONF_NOTIF_LOW_STOCK_SOUND_ENABLED,
     CONF_NOTIF_LOW_STOCK_TITLE,
     CONF_NOTIF_OVERDUE_DELAY,
     CONF_NOTIF_OVERDUE_ENABLED,
     CONF_NOTIF_OVERDUE_MESSAGE,
+    CONF_NOTIF_OVERDUE_SOUND_ENABLED,
     CONF_NOTIF_OVERDUE_TITLE,
     CONF_NOTIF_OVERRIDE_DUE,
     CONF_NOTIF_OVERRIDE_DUE_SOON,
@@ -43,6 +47,7 @@ from .const import (
     CONF_NOTIF_OVERRIDES,
     CONF_NOTIF_TAKEN_ENABLED,
     CONF_NOTIF_TAKEN_MESSAGE,
+    CONF_NOTIF_TAKEN_SOUND_ENABLED,
     CONF_NOTIF_TAKEN_TITLE,
     CONF_NOTIF_TARGET,
     CONF_STOCK_LOW_THRESHOLD,
@@ -61,6 +66,7 @@ from .const import (
     DEFAULT_OVERDUE_DELAY,
     DEFAULT_OVERDUE_MESSAGE,
     DEFAULT_OVERDUE_TITLE,
+    DEFAULT_SOUND_ENABLED,
     DEFAULT_STOCK_LOW_THRESHOLD,
     DEFAULT_STOCK_PER_DOSE,
     DEFAULT_TAKEN_MESSAGE,
@@ -691,6 +697,9 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_DUE_MESSAGE: user_input.get(
                     CONF_NOTIF_DUE_MESSAGE, DEFAULT_DUE_MESSAGE
                 ),
+                CONF_NOTIF_DUE_SOUND_ENABLED: user_input.get(
+                    CONF_NOTIF_DUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                ),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -707,6 +716,10 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_DUE_MESSAGE,
                         default=cfg.get(CONF_NOTIF_DUE_MESSAGE, DEFAULT_DUE_MESSAGE),
                     ): str,
+                    vol.Optional(
+                        CONF_NOTIF_DUE_SOUND_ENABLED,
+                        default=cfg.get(CONF_NOTIF_DUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED),
+                    ): bool,
                 }
             ),
         )
@@ -730,6 +743,9 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_OVERDUE_MESSAGE: user_input.get(
                     CONF_NOTIF_OVERDUE_MESSAGE, DEFAULT_OVERDUE_MESSAGE
                 ),
+                CONF_NOTIF_OVERDUE_SOUND_ENABLED: user_input.get(
+                    CONF_NOTIF_OVERDUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                ),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -746,6 +762,10 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_OVERDUE_MESSAGE,
                         default=cfg.get(CONF_NOTIF_OVERDUE_MESSAGE, DEFAULT_OVERDUE_MESSAGE),
                     ): str,
+                    vol.Optional(
+                        CONF_NOTIF_OVERDUE_SOUND_ENABLED,
+                        default=cfg.get(CONF_NOTIF_OVERDUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED),
+                    ): bool,
                 }
             ),
         )
@@ -769,6 +789,9 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_DUE_SOON_MESSAGE: user_input.get(
                     CONF_NOTIF_DUE_SOON_MESSAGE, DEFAULT_DUE_SOON_MESSAGE
                 ),
+                CONF_NOTIF_DUE_SOON_SOUND_ENABLED: user_input.get(
+                    CONF_NOTIF_DUE_SOON_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                ),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -785,6 +808,12 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_DUE_SOON_MESSAGE,
                         default=cfg.get(CONF_NOTIF_DUE_SOON_MESSAGE, DEFAULT_DUE_SOON_MESSAGE),
                     ): str,
+                    vol.Optional(
+                        CONF_NOTIF_DUE_SOON_SOUND_ENABLED,
+                        default=cfg.get(
+                            CONF_NOTIF_DUE_SOON_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                        ),
+                    ): bool,
                 }
             ),
         )
@@ -808,6 +837,9 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_TAKEN_MESSAGE: user_input.get(
                     CONF_NOTIF_TAKEN_MESSAGE, DEFAULT_TAKEN_MESSAGE
                 ),
+                CONF_NOTIF_TAKEN_SOUND_ENABLED: user_input.get(
+                    CONF_NOTIF_TAKEN_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                ),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -824,6 +856,10 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_TAKEN_MESSAGE,
                         default=cfg.get(CONF_NOTIF_TAKEN_MESSAGE, DEFAULT_TAKEN_MESSAGE),
                     ): str,
+                    vol.Optional(
+                        CONF_NOTIF_TAKEN_SOUND_ENABLED,
+                        default=cfg.get(CONF_NOTIF_TAKEN_SOUND_ENABLED, DEFAULT_SOUND_ENABLED),
+                    ): bool,
                 }
             ),
         )
@@ -847,6 +883,9 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_LOW_STOCK_MESSAGE: user_input.get(
                     CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE
                 ),
+                CONF_NOTIF_LOW_STOCK_SOUND_ENABLED: user_input.get(
+                    CONF_NOTIF_LOW_STOCK_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                ),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -863,6 +902,12 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_LOW_STOCK_MESSAGE,
                         default=cfg.get(CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE),
                     ): str,
+                    vol.Optional(
+                        CONF_NOTIF_LOW_STOCK_SOUND_ENABLED,
+                        default=cfg.get(
+                            CONF_NOTIF_LOW_STOCK_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                        ),
+                    ): bool,
                 }
             ),
         )

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -111,6 +111,17 @@ CONF_NOTIF_LOW_STOCK_ENABLED = "low_stock_enabled"
 CONF_NOTIF_LOW_STOCK_TITLE = "low_stock_title"
 CONF_NOTIF_LOW_STOCK_MESSAGE = "low_stock_message"
 
+# Per-alert-type sound toggle (iOS only — Android sound is channel-based and
+# can't be controlled per-notification via the payload)
+CONF_NOTIF_DUE_SOUND_ENABLED = "due_sound_enabled"
+CONF_NOTIF_OVERDUE_SOUND_ENABLED = "overdue_sound_enabled"
+CONF_NOTIF_DUE_SOON_SOUND_ENABLED = "due_soon_sound_enabled"
+CONF_NOTIF_TAKEN_SOUND_ENABLED = "taken_sound_enabled"
+CONF_NOTIF_LOW_STOCK_SOUND_ENABLED = "low_stock_sound_enabled"
+DEFAULT_SOUND_ENABLED = True
+# Value sent as data.push.sound to mute an iOS notification
+IOS_SILENT_SOUND = ""
+
 # Per-medication override keys
 CONF_NOTIF_OVERRIDES = "notification_overrides"
 CONF_NOTIF_OVERRIDE_OVERDUE = "override_overdue"

--- a/custom_components/medication_tracker/notify.py
+++ b/custom_components/medication_tracker/notify.py
@@ -16,14 +16,18 @@ from .const import (
     CONF_NOTIF_DUE_MESSAGE,
     CONF_NOTIF_DUE_SOON_ENABLED,
     CONF_NOTIF_DUE_SOON_MESSAGE,
+    CONF_NOTIF_DUE_SOON_SOUND_ENABLED,
     CONF_NOTIF_DUE_SOON_TITLE,
+    CONF_NOTIF_DUE_SOUND_ENABLED,
     CONF_NOTIF_DUE_TITLE,
     CONF_NOTIF_LOW_STOCK_ENABLED,
     CONF_NOTIF_LOW_STOCK_MESSAGE,
+    CONF_NOTIF_LOW_STOCK_SOUND_ENABLED,
     CONF_NOTIF_LOW_STOCK_TITLE,
     CONF_NOTIF_OVERDUE_DELAY,
     CONF_NOTIF_OVERDUE_ENABLED,
     CONF_NOTIF_OVERDUE_MESSAGE,
+    CONF_NOTIF_OVERDUE_SOUND_ENABLED,
     CONF_NOTIF_OVERDUE_TITLE,
     CONF_NOTIF_OVERRIDE_DUE,
     CONF_NOTIF_OVERRIDE_DUE_SOON,
@@ -33,6 +37,7 @@ from .const import (
     CONF_NOTIF_OVERRIDES,
     CONF_NOTIF_TAKEN_ENABLED,
     CONF_NOTIF_TAKEN_MESSAGE,
+    CONF_NOTIF_TAKEN_SOUND_ENABLED,
     CONF_NOTIF_TAKEN_TITLE,
     CONF_NOTIF_TARGET,
     DEFAULT_DUE_MESSAGE,
@@ -45,8 +50,10 @@ from .const import (
     DEFAULT_OVERDUE_DELAY,
     DEFAULT_OVERDUE_MESSAGE,
     DEFAULT_OVERDUE_TITLE,
+    DEFAULT_SOUND_ENABLED,
     DEFAULT_TAKEN_MESSAGE,
     DEFAULT_TAKEN_TITLE,
+    IOS_SILENT_SOUND,
 )
 
 from .coordinator import extract_scheduled_time
@@ -79,14 +86,14 @@ def _is_ios(hass: HomeAssistant, target: str) -> bool:
     return False
 
 
-def _build_action_data(hass: HomeAssistant, target: str, med_id: str) -> dict[str, Any]:
+def _build_action_data(is_ios: bool, med_id: str) -> dict[str, Any]:
     """Build platform-appropriate action data for an actionable notification."""
     # Encode med_id in the action identifier so it comes back in the event response
     actions = [
         {"action": f"{ACTION_MARK_TAKEN_PREFIX}{med_id}", "title": "Mark taken"},
         {"action": f"{ACTION_REMIND_PREFIX}{med_id}", "title": "Remind in 5 min"},
     ]
-    if _is_ios(hass, target):
+    if is_ios:
         return {
             "actions": actions,
             "push": {"category": "MEDICATION_ALERT"},
@@ -183,6 +190,9 @@ class MedicationNotifier:
                     },
                     med_id=med_id,
                     actionable=True,
+                    sound_enabled=notif_config.get(
+                        CONF_NOTIF_OVERDUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+                    ),
                 )
             )
 
@@ -251,6 +261,7 @@ class MedicationNotifier:
             },
             med_id=med_id,
             actionable=False,
+            sound_enabled=notif_config.get(CONF_NOTIF_TAKEN_SOUND_ENABLED, DEFAULT_SOUND_ENABLED),
         )
 
     # ------------------------------------------------------------------
@@ -296,6 +307,7 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=True,
+            sound_enabled=notif_config.get(CONF_NOTIF_DUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED),
         )
         self._fired.add(fire_key)
 
@@ -353,6 +365,7 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=True,
+            sound_enabled=notif_config.get(CONF_NOTIF_OVERDUE_SOUND_ENABLED, DEFAULT_SOUND_ENABLED),
         )
         self._fired.add(fire_key)
 
@@ -395,6 +408,9 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=True,
+            sound_enabled=notif_config.get(
+                CONF_NOTIF_DUE_SOON_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+            ),
         )
         self._fired.add(fire_key)
 
@@ -439,6 +455,9 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=False,
+            sound_enabled=notif_config.get(
+                CONF_NOTIF_LOW_STOCK_SOUND_ENABLED, DEFAULT_SOUND_ENABLED
+            ),
         )
         self._low_stock_fired.add(med_id)
 
@@ -454,6 +473,7 @@ class MedicationNotifier:
         placeholders: dict[str, str],
         med_id: str = "",
         actionable: bool = False,
+        sound_enabled: bool = True,
     ) -> None:
         """Render templates and call the notify service."""
         target = notif_config.get(CONF_NOTIF_TARGET, DEFAULT_NOTIFY_TARGET)
@@ -468,8 +488,16 @@ class MedicationNotifier:
 
         service_data: dict[str, Any] = {"title": title, "message": message}
 
+        is_ios = _is_ios(self._hass, target)
+        data: dict[str, Any] = {}
         if actionable and med_id and target != DEFAULT_NOTIFY_TARGET:
-            service_data["data"] = _build_action_data(self._hass, target, med_id)
+            data.update(_build_action_data(is_ios, med_id))
+        if not sound_enabled and is_ios:
+            # Android sound is channel-based and can't be muted per-notification
+            # via the payload, so this only takes effect on iOS.
+            data["push"] = {**data.get("push", {}), "sound": IOS_SILENT_SOUND}
+        if data:
+            service_data["data"] = data
 
         _LOGGER.debug(
             "Sending notification via %s: title=%r, actionable=%s", target, title, actionable

--- a/custom_components/medication_tracker/strings.json
+++ b/custom_components/medication_tracker/strings.json
@@ -65,7 +65,8 @@
         "description": "Customise the message sent when a dose is due.",
         "data": {
           "due_title": "Notification title",
-          "due_message": "Notification message"
+          "due_message": "Notification message",
+          "due_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_overdue_message": {
@@ -73,7 +74,8 @@
         "description": "Customise the message sent when a dose is overdue.",
         "data": {
           "overdue_title": "Notification title",
-          "overdue_message": "Notification message"
+          "overdue_message": "Notification message",
+          "overdue_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_due_soon_message": {
@@ -81,7 +83,8 @@
         "description": "Customise the message sent when a dose is due soon.",
         "data": {
           "due_soon_title": "Notification title",
-          "due_soon_message": "Notification message"
+          "due_soon_message": "Notification message",
+          "due_soon_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_taken_message": {
@@ -89,7 +92,8 @@
         "description": "Customise the message sent when a dose is marked as taken.",
         "data": {
           "taken_title": "Notification title",
-          "taken_message": "Notification message"
+          "taken_message": "Notification message",
+          "taken_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_low_stock_message": {
@@ -97,7 +101,8 @@
         "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.",
         "data": {
           "low_stock_title": "Notification title",
-          "low_stock_message": "Notification message"
+          "low_stock_message": "Notification message",
+          "low_stock_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_per_medication": {

--- a/custom_components/medication_tracker/translations/en.json
+++ b/custom_components/medication_tracker/translations/en.json
@@ -65,7 +65,8 @@
         "description": "Customise the message sent when a dose is due.",
         "data": {
           "due_title": "Notification title",
-          "due_message": "Notification message"
+          "due_message": "Notification message",
+          "due_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_overdue_message": {
@@ -73,7 +74,8 @@
         "description": "Customise the message sent when a dose is overdue.",
         "data": {
           "overdue_title": "Notification title",
-          "overdue_message": "Notification message"
+          "overdue_message": "Notification message",
+          "overdue_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_due_soon_message": {
@@ -81,7 +83,8 @@
         "description": "Customise the message sent when a dose is due soon.",
         "data": {
           "due_soon_title": "Notification title",
-          "due_soon_message": "Notification message"
+          "due_soon_message": "Notification message",
+          "due_soon_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_taken_message": {
@@ -89,7 +92,8 @@
         "description": "Customise the message sent when a dose is marked as taken.",
         "data": {
           "taken_title": "Notification title",
-          "taken_message": "Notification message"
+          "taken_message": "Notification message",
+          "taken_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_low_stock_message": {
@@ -97,7 +101,8 @@
         "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.",
         "data": {
           "low_stock_title": "Notification title",
-          "low_stock_message": "Notification message"
+          "low_stock_message": "Notification message",
+          "low_stock_sound_enabled": "Play a sound (iOS only — Android sound is set in your device's notification settings)"
         }
       },
       "notification_per_medication": {


### PR DESCRIPTION
## Summary
Adds a "Play a sound" on/off toggle for each notification alert type (due, overdue, due soon, taken, low stock), alongside the existing title/message template settings.

- New `CONF_NOTIF_<TYPE>_SOUND_ENABLED` boolean per alert type, defaulting to **on** — matches existing behavior exactly for everyone upgrading, no regression
- Wired into `notify.py`'s `_send`: when off and the target is detected as an iOS device (reusing the existing `_is_ios` check), injects `data.push.sound = ""` to mute that notification
- **Android is intentionally out of scope for this toggle** — sound on Android is tied to notification *channels*, not the payload, so it can't be controlled per-notification from the integration. Android users configure sound in their device's own notification settings instead. Documented in the README.
- Scope note based on research into the actual iOS Companion App docs: a full "pick from a list of sounds" dropdown wasn't pursued because iOS doesn't ship a small enumerable preset list (160+ bundled files, plus user-imported custom sounds) and Android sound can't be set via payload at all — see discussion on the linked issue for the fuller writeup. Went with the simpler on/off toggle instead, per feedback.

## Test plan
- [x] `ruff check custom_components/` — passes
- [x] `flake8 custom_components/medication_tracker/ --max-line-length=120 --ignore=E501,W503` (Python 3.12, matching CI) — passes
- [x] `python3.12 -m py_compile` on all changed files — passes
- [x] `strings.json` / `translations/en.json` validated as valid JSON and kept in sync
- [x] Independent adversarial review confirmed default-behavior parity (byte-identical `service_data` when sound is on, the default) and correct merging with the existing actionable-notification payload on iOS
- [ ] Manual verification in a running Home Assistant instance with a real iOS device (not available in this environment) — recommend confirming the mute actually takes effect; the exact "no sound" payload value isn't fully documented by Home Assistant, so this is the one area I'd want eyes-on before considering it fully verified


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_