### PR TITLE
Add per-platform Notification Sounds (iOS/Android) per alert type

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,26 @@ Notifications on iOS and Android include **Mark taken** and **Remind in 5 min** 
 
 The low stock alert fires once when stock crosses the threshold and won't repeat until you restock above it (via the `adjust_stock` service) and it drops low again.
 
-After the global settings, you can also customise the notification title and message templates for each alert type.
+After the global settings, you can also customise the notification title and message templates for each alert type — and, alongside each template, a **Notification Sounds** section with separate iOS and Android options (they control sound differently, so each platform has its own settings). Everything defaults to **Default** — today's plain device notification tone — until you actively change it, so upgrading changes nothing until you visit this screen.
+
+**iOS:**
+
+| Option | Behavior |
+|--------|----------|
+| Default | The device's normal notification sound (unchanged from today) |
+| Critical | Bypasses mute and Do Not Disturb. ⚠️ Only works if you've granted the Home Assistant app **Critical Alerts** permission in iOS Settings → Notifications → Home Assistant — a separate opt-in from normal notification permission |
+| Time-sensitive | Plays a sound and is flagged "Time Sensitive" on the lock screen. You can set a custom sound name (defaults to `default`) — it must be `"default"` or the exact filename (with extension) of a sound already bundled with or imported into the Home Assistant iOS app; an unrecognized name just plays nothing, so verify it works before relying on it |
+| No sound | Silences that alert type entirely on iOS |
+
+**Android:**
+
+| Option | Behavior |
+|--------|----------|
+| Default | The device's normal notification sound (unchanged from today) |
+| Critical | Routes to a dedicated **Critical Medication** notification channel, with an Importance you choose (Min/Low/Default/High/Max) |
+| No sound | Routes to a dedicated silent channel |
+
+Android sound isn't controllable per-notification — it's tied to the notification *channel*, and Android locks a channel's sound/importance the first time it's created. If you need to change it later, do so in your phone's own notification settings (Settings → Apps → Home Assistant → Notifications → the relevant channel), not from this integration.
 
 #### Per-medication notification overrides
 

--- a/custom_components/medication_tracker/config_flow.py
+++ b/custom_components/medication_tracker/config_flow.py
@@ -11,6 +11,8 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResu
 from homeassistant.core import callback
 
 from .const import (
+    ANDROID_IMPORTANCE_OPTIONS,
+    ANDROID_SOUND_MODE_OPTIONS,
     CONF_AS_NEEDED_MAX_PER_24H,
     CONF_AS_NEEDED_MAX_PER_DAY,
     CONF_AS_NEEDED_MIN_HOURS,
@@ -48,6 +50,8 @@ from .const import (
     CONF_STOCK_LOW_THRESHOLD,
     CONF_STOCK_PER_DOSE,
     CONF_STOCK_TRACKING_ENABLED,
+    DEFAULT_ANDROID_IMPORTANCE,
+    DEFAULT_ANDROID_SOUND_MODE,
     DEFAULT_AS_NEEDED_MAX_PER_24H,
     DEFAULT_AS_NEEDED_MAX_PER_DAY,
     DEFAULT_AS_NEEDED_MIN_HOURS,
@@ -55,6 +59,8 @@ from .const import (
     DEFAULT_DUE_SOON_MESSAGE,
     DEFAULT_DUE_SOON_TITLE,
     DEFAULT_DUE_TITLE,
+    DEFAULT_IOS_SOUND_MODE,
+    DEFAULT_IOS_SOUND_NAME,
     DEFAULT_LOW_STOCK_MESSAGE,
     DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
@@ -66,8 +72,10 @@ from .const import (
     DEFAULT_TAKEN_MESSAGE,
     DEFAULT_TAKEN_TITLE,
     DOMAIN,
+    IOS_SOUND_MODE_OPTIONS,
     MED_TYPE_AS_NEEDED,
     MED_TYPE_SCHEDULED,
+    NOTIF_SOUND_KEYS_BY_TYPE,
 )
 
 _TIME_PATTERN = re.compile(r"^\d{2}:\d{2}$")
@@ -151,6 +159,43 @@ def _stock_config_from_input(
         CONF_STOCK_PER_DOSE: user_input.get(CONF_STOCK_PER_DOSE, DEFAULT_STOCK_PER_DOSE),
         CONF_STOCK_LOW_THRESHOLD: user_input.get(
             CONF_STOCK_LOW_THRESHOLD, DEFAULT_STOCK_LOW_THRESHOLD
+        ),
+    }
+
+
+def _sound_schema_fields(type_key: str, cfg: dict[str, Any]) -> dict[Any, Any]:
+    """Return the iOS/Android notification sound schema fields for one alert type."""
+    ios_mode_key, ios_name_key, android_mode_key, android_importance_key = (
+        NOTIF_SOUND_KEYS_BY_TYPE[type_key]
+    )
+    return {
+        vol.Optional(
+            ios_mode_key, default=cfg.get(ios_mode_key, DEFAULT_IOS_SOUND_MODE)
+        ): vol.In(IOS_SOUND_MODE_OPTIONS),
+        vol.Optional(
+            ios_name_key, default=cfg.get(ios_name_key, DEFAULT_IOS_SOUND_NAME)
+        ): str,
+        vol.Optional(
+            android_mode_key, default=cfg.get(android_mode_key, DEFAULT_ANDROID_SOUND_MODE)
+        ): vol.In(ANDROID_SOUND_MODE_OPTIONS),
+        vol.Optional(
+            android_importance_key,
+            default=cfg.get(android_importance_key, DEFAULT_ANDROID_IMPORTANCE),
+        ): vol.In(ANDROID_IMPORTANCE_OPTIONS),
+    }
+
+
+def _sound_config_from_input(type_key: str, user_input: dict[str, Any]) -> dict[str, Any]:
+    """Extract the iOS/Android sound fields for one alert type from form input."""
+    ios_mode_key, ios_name_key, android_mode_key, android_importance_key = (
+        NOTIF_SOUND_KEYS_BY_TYPE[type_key]
+    )
+    return {
+        ios_mode_key: user_input.get(ios_mode_key, DEFAULT_IOS_SOUND_MODE),
+        ios_name_key: user_input.get(ios_name_key, DEFAULT_IOS_SOUND_NAME),
+        android_mode_key: user_input.get(android_mode_key, DEFAULT_ANDROID_SOUND_MODE),
+        android_importance_key: user_input.get(
+            android_importance_key, DEFAULT_ANDROID_IMPORTANCE
         ),
     }
 
@@ -691,6 +736,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_DUE_MESSAGE: user_input.get(
                     CONF_NOTIF_DUE_MESSAGE, DEFAULT_DUE_MESSAGE
                 ),
+                **_sound_config_from_input("due", user_input),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -707,6 +753,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_DUE_MESSAGE,
                         default=cfg.get(CONF_NOTIF_DUE_MESSAGE, DEFAULT_DUE_MESSAGE),
                     ): str,
+                    **_sound_schema_fields("due", cfg),
                 }
             ),
         )
@@ -730,6 +777,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_OVERDUE_MESSAGE: user_input.get(
                     CONF_NOTIF_OVERDUE_MESSAGE, DEFAULT_OVERDUE_MESSAGE
                 ),
+                **_sound_config_from_input("overdue", user_input),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -746,6 +794,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_OVERDUE_MESSAGE,
                         default=cfg.get(CONF_NOTIF_OVERDUE_MESSAGE, DEFAULT_OVERDUE_MESSAGE),
                     ): str,
+                    **_sound_schema_fields("overdue", cfg),
                 }
             ),
         )
@@ -769,6 +818,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_DUE_SOON_MESSAGE: user_input.get(
                     CONF_NOTIF_DUE_SOON_MESSAGE, DEFAULT_DUE_SOON_MESSAGE
                 ),
+                **_sound_config_from_input("due_soon", user_input),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -785,6 +835,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_DUE_SOON_MESSAGE,
                         default=cfg.get(CONF_NOTIF_DUE_SOON_MESSAGE, DEFAULT_DUE_SOON_MESSAGE),
                     ): str,
+                    **_sound_schema_fields("due_soon", cfg),
                 }
             ),
         )
@@ -808,6 +859,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_TAKEN_MESSAGE: user_input.get(
                     CONF_NOTIF_TAKEN_MESSAGE, DEFAULT_TAKEN_MESSAGE
                 ),
+                **_sound_config_from_input("taken", user_input),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -824,6 +876,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_TAKEN_MESSAGE,
                         default=cfg.get(CONF_NOTIF_TAKEN_MESSAGE, DEFAULT_TAKEN_MESSAGE),
                     ): str,
+                    **_sound_schema_fields("taken", cfg),
                 }
             ),
         )
@@ -847,6 +900,7 @@ class MedicationOptionsFlow(OptionsFlow):
                 CONF_NOTIF_LOW_STOCK_MESSAGE: user_input.get(
                     CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE
                 ),
+                **_sound_config_from_input("low_stock", user_input),
             }
             await coordinator.async_update_notification_config(updated)
             return await self.async_step_notifications()
@@ -863,6 +917,7 @@ class MedicationOptionsFlow(OptionsFlow):
                         CONF_NOTIF_LOW_STOCK_MESSAGE,
                         default=cfg.get(CONF_NOTIF_LOW_STOCK_MESSAGE, DEFAULT_LOW_STOCK_MESSAGE),
                     ): str,
+                    **_sound_schema_fields("low_stock", cfg),
                 }
             ),
         )

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -111,6 +111,118 @@ CONF_NOTIF_LOW_STOCK_ENABLED = "low_stock_enabled"
 CONF_NOTIF_LOW_STOCK_TITLE = "low_stock_title"
 CONF_NOTIF_LOW_STOCK_MESSAGE = "low_stock_message"
 
+# ---------------------------------------------------------------------------
+# Notification sounds (per alert type, per platform)
+# ---------------------------------------------------------------------------
+
+# iOS sound modes
+SOUND_MODE_DEFAULT = "default"
+SOUND_MODE_CRITICAL = "critical"
+SOUND_MODE_TIME_SENSITIVE = "time_sensitive"
+SOUND_MODE_NONE = "none"
+
+IOS_SOUND_MODE_OPTIONS = {
+    SOUND_MODE_DEFAULT: "Default (device's normal notification sound)",
+    SOUND_MODE_CRITICAL: "Critical — bypasses mute & Do Not Disturb",
+    SOUND_MODE_TIME_SENSITIVE: "Time-sensitive — plays a sound",
+    SOUND_MODE_NONE: "No sound",
+}
+
+# Android only has Default/Critical/None — sound itself isn't payload-settable,
+# only the notification channel + importance, which the user then configures
+# on-device (see ANDROID_CRITICAL_CHANNEL / ANDROID_SILENT_CHANNEL below).
+ANDROID_SOUND_MODE_OPTIONS = {
+    SOUND_MODE_DEFAULT: "Default (device's normal notification sound)",
+    SOUND_MODE_CRITICAL: "Critical — dedicated high-priority channel",
+    SOUND_MODE_NONE: "No sound",
+}
+
+ANDROID_IMPORTANCE_OPTIONS = {
+    "min": "Min",
+    "low": "Low",
+    "default": "Default",
+    "high": "High",
+    "max": "Max",
+}
+
+DEFAULT_IOS_SOUND_MODE = SOUND_MODE_DEFAULT
+DEFAULT_IOS_SOUND_NAME = "default"
+DEFAULT_ANDROID_SOUND_MODE = SOUND_MODE_DEFAULT
+DEFAULT_ANDROID_IMPORTANCE = "default"
+
+# Critical alerts require the user to have granted the HA app "Critical
+# Alerts" permission in iOS Settings, separate from ordinary notification
+# permission — bypasses mute and Do Not Disturb when granted.
+IOS_CRITICAL_SOUND = {"name": "default", "critical": 1, "volume": 1.0}
+
+# Android channels are created once (on first send) and locked from then on —
+# later importance/sound changes via the payload are ignored, only lowering
+# takes effect. Users adjust sound per-channel in their device's own settings.
+ANDROID_CRITICAL_CHANNEL = "Critical Medication"
+ANDROID_SILENT_CHANNEL = "Medication Tracker (Silent)"
+ANDROID_SILENT_IMPORTANCE = "low"
+
+# Per-alert-type sound config keys
+CONF_NOTIF_DUE_IOS_SOUND_MODE = "due_ios_sound_mode"
+CONF_NOTIF_DUE_IOS_SOUND_NAME = "due_ios_sound_name"
+CONF_NOTIF_DUE_ANDROID_SOUND_MODE = "due_android_sound_mode"
+CONF_NOTIF_DUE_ANDROID_IMPORTANCE = "due_android_importance"
+
+CONF_NOTIF_OVERDUE_IOS_SOUND_MODE = "overdue_ios_sound_mode"
+CONF_NOTIF_OVERDUE_IOS_SOUND_NAME = "overdue_ios_sound_name"
+CONF_NOTIF_OVERDUE_ANDROID_SOUND_MODE = "overdue_android_sound_mode"
+CONF_NOTIF_OVERDUE_ANDROID_IMPORTANCE = "overdue_android_importance"
+
+CONF_NOTIF_DUE_SOON_IOS_SOUND_MODE = "due_soon_ios_sound_mode"
+CONF_NOTIF_DUE_SOON_IOS_SOUND_NAME = "due_soon_ios_sound_name"
+CONF_NOTIF_DUE_SOON_ANDROID_SOUND_MODE = "due_soon_android_sound_mode"
+CONF_NOTIF_DUE_SOON_ANDROID_IMPORTANCE = "due_soon_android_importance"
+
+CONF_NOTIF_TAKEN_IOS_SOUND_MODE = "taken_ios_sound_mode"
+CONF_NOTIF_TAKEN_IOS_SOUND_NAME = "taken_ios_sound_name"
+CONF_NOTIF_TAKEN_ANDROID_SOUND_MODE = "taken_android_sound_mode"
+CONF_NOTIF_TAKEN_ANDROID_IMPORTANCE = "taken_android_importance"
+
+CONF_NOTIF_LOW_STOCK_IOS_SOUND_MODE = "low_stock_ios_sound_mode"
+CONF_NOTIF_LOW_STOCK_IOS_SOUND_NAME = "low_stock_ios_sound_name"
+CONF_NOTIF_LOW_STOCK_ANDROID_SOUND_MODE = "low_stock_android_sound_mode"
+CONF_NOTIF_LOW_STOCK_ANDROID_IMPORTANCE = "low_stock_android_importance"
+
+# Per alert-type field key groups, used to build the sound schema/payload
+# generically instead of repeating the same 4-field block five times.
+NOTIF_SOUND_KEYS_BY_TYPE = {
+    "due": (
+        CONF_NOTIF_DUE_IOS_SOUND_MODE,
+        CONF_NOTIF_DUE_IOS_SOUND_NAME,
+        CONF_NOTIF_DUE_ANDROID_SOUND_MODE,
+        CONF_NOTIF_DUE_ANDROID_IMPORTANCE,
+    ),
+    "overdue": (
+        CONF_NOTIF_OVERDUE_IOS_SOUND_MODE,
+        CONF_NOTIF_OVERDUE_IOS_SOUND_NAME,
+        CONF_NOTIF_OVERDUE_ANDROID_SOUND_MODE,
+        CONF_NOTIF_OVERDUE_ANDROID_IMPORTANCE,
+    ),
+    "due_soon": (
+        CONF_NOTIF_DUE_SOON_IOS_SOUND_MODE,
+        CONF_NOTIF_DUE_SOON_IOS_SOUND_NAME,
+        CONF_NOTIF_DUE_SOON_ANDROID_SOUND_MODE,
+        CONF_NOTIF_DUE_SOON_ANDROID_IMPORTANCE,
+    ),
+    "taken": (
+        CONF_NOTIF_TAKEN_IOS_SOUND_MODE,
+        CONF_NOTIF_TAKEN_IOS_SOUND_NAME,
+        CONF_NOTIF_TAKEN_ANDROID_SOUND_MODE,
+        CONF_NOTIF_TAKEN_ANDROID_IMPORTANCE,
+    ),
+    "low_stock": (
+        CONF_NOTIF_LOW_STOCK_IOS_SOUND_MODE,
+        CONF_NOTIF_LOW_STOCK_IOS_SOUND_NAME,
+        CONF_NOTIF_LOW_STOCK_ANDROID_SOUND_MODE,
+        CONF_NOTIF_LOW_STOCK_ANDROID_IMPORTANCE,
+    ),
+}
+
 # Per-medication override keys
 CONF_NOTIF_OVERRIDES = "notification_overrides"
 CONF_NOTIF_OVERRIDE_OVERDUE = "override_overdue"

--- a/custom_components/medication_tracker/notify.py
+++ b/custom_components/medication_tracker/notify.py
@@ -11,6 +11,9 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_call_later
 
 from .const import (
+    ANDROID_CRITICAL_CHANNEL,
+    ANDROID_SILENT_CHANNEL,
+    ANDROID_SILENT_IMPORTANCE,
     MED_TYPE_AS_NEEDED,
     CONF_NOTIF_DUE_ENABLED,
     CONF_NOTIF_DUE_MESSAGE,
@@ -35,10 +38,14 @@ from .const import (
     CONF_NOTIF_TAKEN_MESSAGE,
     CONF_NOTIF_TAKEN_TITLE,
     CONF_NOTIF_TARGET,
+    DEFAULT_ANDROID_IMPORTANCE,
+    DEFAULT_ANDROID_SOUND_MODE,
     DEFAULT_DUE_MESSAGE,
     DEFAULT_DUE_SOON_MESSAGE,
     DEFAULT_DUE_SOON_TITLE,
     DEFAULT_DUE_TITLE,
+    DEFAULT_IOS_SOUND_MODE,
+    DEFAULT_IOS_SOUND_NAME,
     DEFAULT_LOW_STOCK_MESSAGE,
     DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
@@ -47,6 +54,11 @@ from .const import (
     DEFAULT_OVERDUE_TITLE,
     DEFAULT_TAKEN_MESSAGE,
     DEFAULT_TAKEN_TITLE,
+    IOS_CRITICAL_SOUND,
+    NOTIF_SOUND_KEYS_BY_TYPE,
+    SOUND_MODE_CRITICAL,
+    SOUND_MODE_NONE,
+    SOUND_MODE_TIME_SENSITIVE,
 )
 
 from .coordinator import extract_scheduled_time
@@ -79,14 +91,14 @@ def _is_ios(hass: HomeAssistant, target: str) -> bool:
     return False
 
 
-def _build_action_data(hass: HomeAssistant, target: str, med_id: str) -> dict[str, Any]:
+def _build_action_data(is_ios: bool, med_id: str) -> dict[str, Any]:
     """Build platform-appropriate action data for an actionable notification."""
     # Encode med_id in the action identifier so it comes back in the event response
     actions = [
         {"action": f"{ACTION_MARK_TAKEN_PREFIX}{med_id}", "title": "Mark taken"},
         {"action": f"{ACTION_REMIND_PREFIX}{med_id}", "title": "Remind in 5 min"},
     ]
-    if _is_ios(hass, target):
+    if is_ios:
         return {
             "actions": actions,
             "push": {"category": "MEDICATION_ALERT"},
@@ -96,6 +108,44 @@ def _build_action_data(hass: HomeAssistant, target: str, med_id: str) -> dict[st
         "tag": f"medication_{med_id}",
         "persistent": False,
     }
+
+
+def _apply_sound(
+    data: dict[str, Any],
+    notif_config: dict[str, Any],
+    sound_keys: tuple[str, str, str, str],
+    is_ios: bool,
+) -> None:
+    """Mutate `data` in place per the configured sound mode for this alert type."""
+    ios_mode_key, ios_name_key, android_mode_key, android_importance_key = sound_keys
+    if is_ios:
+        mode = notif_config.get(ios_mode_key, DEFAULT_IOS_SOUND_MODE)
+        if mode == SOUND_MODE_CRITICAL:
+            data["push"] = {
+                **data.get("push", {}),
+                "sound": IOS_CRITICAL_SOUND,
+                "interruption-level": "critical",
+            }
+        elif mode == SOUND_MODE_TIME_SENSITIVE:
+            sound_name = notif_config.get(ios_name_key) or DEFAULT_IOS_SOUND_NAME
+            data["push"] = {
+                **data.get("push", {}),
+                "sound": sound_name,
+                "interruption-level": "time-sensitive",
+            }
+        elif mode == SOUND_MODE_NONE:
+            data["push"] = {**data.get("push", {}), "sound": ""}
+        # SOUND_MODE_DEFAULT: leave the payload untouched — today's behavior.
+    else:
+        mode = notif_config.get(android_mode_key, DEFAULT_ANDROID_SOUND_MODE)
+        if mode == SOUND_MODE_CRITICAL:
+            importance = notif_config.get(android_importance_key, DEFAULT_ANDROID_IMPORTANCE)
+            data["channel"] = ANDROID_CRITICAL_CHANNEL
+            data["importance"] = importance
+        elif mode == SOUND_MODE_NONE:
+            data["channel"] = ANDROID_SILENT_CHANNEL
+            data["importance"] = ANDROID_SILENT_IMPORTANCE
+        # SOUND_MODE_DEFAULT: leave the payload untouched — today's behavior.
 
 
 class MedicationNotifier:
@@ -183,6 +233,7 @@ class MedicationNotifier:
                     },
                     med_id=med_id,
                     actionable=True,
+                    sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["overdue"],
                 )
             )
 
@@ -251,6 +302,7 @@ class MedicationNotifier:
             },
             med_id=med_id,
             actionable=False,
+            sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["taken"],
         )
 
     # ------------------------------------------------------------------
@@ -296,6 +348,7 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=True,
+            sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["due"],
         )
         self._fired.add(fire_key)
 
@@ -353,6 +406,7 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=True,
+            sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["overdue"],
         )
         self._fired.add(fire_key)
 
@@ -395,6 +449,7 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=True,
+            sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["due_soon"],
         )
         self._fired.add(fire_key)
 
@@ -439,6 +494,7 @@ class MedicationNotifier:
             },
             med_id=med["id"],
             actionable=False,
+            sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["low_stock"],
         )
         self._low_stock_fired.add(med_id)
 
@@ -454,6 +510,7 @@ class MedicationNotifier:
         placeholders: dict[str, str],
         med_id: str = "",
         actionable: bool = False,
+        sound_keys: tuple[str, str, str, str] | None = None,
     ) -> None:
         """Render templates and call the notify service."""
         target = notif_config.get(CONF_NOTIF_TARGET, DEFAULT_NOTIFY_TARGET)
@@ -468,8 +525,14 @@ class MedicationNotifier:
 
         service_data: dict[str, Any] = {"title": title, "message": message}
 
+        is_ios = _is_ios(self._hass, target)
+        data: dict[str, Any] = {}
         if actionable and med_id and target != DEFAULT_NOTIFY_TARGET:
-            service_data["data"] = _build_action_data(self._hass, target, med_id)
+            data.update(_build_action_data(is_ios, med_id))
+        if sound_keys and target != DEFAULT_NOTIFY_TARGET:
+            _apply_sound(data, notif_config, sound_keys, is_ios)
+        if data:
+            service_data["data"] = data
 
         _LOGGER.debug(
             "Sending notification via %s: title=%r, actionable=%s", target, title, actionable

--- a/custom_components/medication_tracker/strings.json
+++ b/custom_components/medication_tracker/strings.json
@@ -62,42 +62,62 @@
       },
       "notification_due_message": {
         "title": "Due now message template",
-        "description": "Customise the message sent when a dose is due.",
+        "description": "Customise the message sent when a dose is due.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "due_title": "Notification title",
-          "due_message": "Notification message"
+          "due_message": "Notification message",
+          "due_ios_sound_mode": "iOS — Sound behavior",
+          "due_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "due_android_sound_mode": "Android — Sound behavior",
+          "due_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_overdue_message": {
         "title": "Overdue message template",
-        "description": "Customise the message sent when a dose is overdue.",
+        "description": "Customise the message sent when a dose is overdue.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "overdue_title": "Notification title",
-          "overdue_message": "Notification message"
+          "overdue_message": "Notification message",
+          "overdue_ios_sound_mode": "iOS — Sound behavior",
+          "overdue_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "overdue_android_sound_mode": "Android — Sound behavior",
+          "overdue_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_due_soon_message": {
         "title": "Due soon message template",
-        "description": "Customise the message sent when a dose is due soon.",
+        "description": "Customise the message sent when a dose is due soon.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "due_soon_title": "Notification title",
-          "due_soon_message": "Notification message"
+          "due_soon_message": "Notification message",
+          "due_soon_ios_sound_mode": "iOS — Sound behavior",
+          "due_soon_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "due_soon_android_sound_mode": "Android — Sound behavior",
+          "due_soon_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_taken_message": {
         "title": "Taken confirmation message template",
-        "description": "Customise the message sent when a dose is marked as taken.",
+        "description": "Customise the message sent when a dose is marked as taken.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "taken_title": "Notification title",
-          "taken_message": "Notification message"
+          "taken_message": "Notification message",
+          "taken_ios_sound_mode": "iOS — Sound behavior",
+          "taken_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "taken_android_sound_mode": "Android — Sound behavior",
+          "taken_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_low_stock_message": {
         "title": "Low stock message template",
-        "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.",
+        "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "low_stock_title": "Notification title",
-          "low_stock_message": "Notification message"
+          "low_stock_message": "Notification message",
+          "low_stock_ios_sound_mode": "iOS — Sound behavior",
+          "low_stock_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "low_stock_android_sound_mode": "Android — Sound behavior",
+          "low_stock_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_per_medication": {

--- a/custom_components/medication_tracker/translations/en.json
+++ b/custom_components/medication_tracker/translations/en.json
@@ -62,42 +62,62 @@
       },
       "notification_due_message": {
         "title": "Due now message template",
-        "description": "Customise the message sent when a dose is due.",
+        "description": "Customise the message sent when a dose is due.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "due_title": "Notification title",
-          "due_message": "Notification message"
+          "due_message": "Notification message",
+          "due_ios_sound_mode": "iOS — Sound behavior",
+          "due_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "due_android_sound_mode": "Android — Sound behavior",
+          "due_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_overdue_message": {
         "title": "Overdue message template",
-        "description": "Customise the message sent when a dose is overdue.",
+        "description": "Customise the message sent when a dose is overdue.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "overdue_title": "Notification title",
-          "overdue_message": "Notification message"
+          "overdue_message": "Notification message",
+          "overdue_ios_sound_mode": "iOS — Sound behavior",
+          "overdue_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "overdue_android_sound_mode": "Android — Sound behavior",
+          "overdue_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_due_soon_message": {
         "title": "Due soon message template",
-        "description": "Customise the message sent when a dose is due soon.",
+        "description": "Customise the message sent when a dose is due soon.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "due_soon_title": "Notification title",
-          "due_soon_message": "Notification message"
+          "due_soon_message": "Notification message",
+          "due_soon_ios_sound_mode": "iOS — Sound behavior",
+          "due_soon_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "due_soon_android_sound_mode": "Android — Sound behavior",
+          "due_soon_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_taken_message": {
         "title": "Taken confirmation message template",
-        "description": "Customise the message sent when a dose is marked as taken.",
+        "description": "Customise the message sent when a dose is marked as taken.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "taken_title": "Notification title",
-          "taken_message": "Notification message"
+          "taken_message": "Notification message",
+          "taken_ios_sound_mode": "iOS — Sound behavior",
+          "taken_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "taken_android_sound_mode": "Android — Sound behavior",
+          "taken_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_low_stock_message": {
         "title": "Low stock message template",
-        "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.",
+        "description": "Customise the message sent when a medication's stock runs low. You can use {stock} to show the remaining quantity.\n\n**Notification Sounds** — iOS and Android control sound differently, so each has its own options below. ⚠️ iOS Critical bypasses mute and Do Not Disturb, but only works once you've granted the Home Assistant app \"Critical Alerts\" permission in iOS Settings → Notifications → Home Assistant. Android Critical routes to a dedicated \"Critical Medication\" channel — Android locks a channel's sound/importance the first time it's created, so adjust it afterward in your phone's own notification settings if needed.",
         "data": {
           "low_stock_title": "Notification title",
-          "low_stock_message": "Notification message"
+          "low_stock_message": "Notification message",
+          "low_stock_ios_sound_mode": "iOS — Sound behavior",
+          "low_stock_ios_sound_name": "iOS — Time-sensitive sound name (used only when set to Time-sensitive above)",
+          "low_stock_android_sound_mode": "Android — Sound behavior",
+          "low_stock_android_importance": "Android — Channel importance (used only when set to Critical above)"
         }
       },
       "notification_per_medication": {


### PR DESCRIPTION
## Summary
Closes #8. Replaces the earlier simple on/off sound toggle (PR #9, reverted) with a proper per-platform "Notification Sounds" design, per alert type (due, overdue, due soon, taken, low stock):

**iOS** — Default / Critical / Time-sensitive / No sound
- Critical bypasses mute & Do Not Disturb via `data.push.sound = {name: "default", critical: 1, volume: 1.0}` + `interruption-level: critical`. Warned in the UI that this requires the user to have granted the HA app's **Critical Alerts** permission in iOS Settings — a separate opt-in from normal notification permission.
- Time-sensitive sets `interruption-level: time-sensitive` with a custom, editable sound name (defaults to `"default"`, since I couldn't independently verify "Rattle" is an actually-bundled sound name against HA's docs — free text so it's adjustable if wrong).
- No sound sets an empty `push.sound`.

**Android** — Default / Critical / No sound
- Critical routes to a dedicated `"Critical Medication"` channel with a user-chosen importance (Min/Low/Default/High/Max — verified against HA's actual Android companion docs, which do support exactly these 5 values via `data.importance`).
- No sound routes to a separate silent channel.
- Noted in the UI: Android locks a channel's sound/importance on first creation: later payload changes are ignored, so users adjust it afterward in their phone's own notification settings.

**Backward compatibility**: every field defaults to `"default"`, which leaves the payload completely untouched — verified byte-identical to pre-diff behavior for every combination of platform/actionable/alert-type in an independent adversarial review. Nothing changes for anyone until they actively visit the new Notification Sounds section (added to each alert type's existing message-template screen, since HA's config-flow forms don't support true collapsible sections at this integration's minimum supported HA version).

## Test plan
- [x] `ruff check custom_components/` — passes
- [x] `flake8 custom_components/medication_tracker/ --max-line-length=120 --ignore=E501,W503` (Python 3.12, matching CI) — passes
- [x] `python3.12 -m py_compile` on all changed files — passes
- [x] `strings.json` / `translations/en.json` validated as valid JSON, byte-identical, all 20 new field labels present in both
- [x] Independent adversarial review: confirmed default-mode payload parity (byte-identical to pre-diff for both actionable and non-actionable sends, iOS and Android), correct `push` dict merging alongside the existing actionable-notification `category` field, correct per-type key mapping (no cross-type mix-ups across the 5 alert types × 4 fields), and that sound logic is correctly skipped entirely for the `persistent_notification` target
- [x] Verified iOS critical/time-sensitive payload structure and Android importance values against Home Assistant's actual companion app documentation (not guessed)
- [ ] Manual verification on real iOS/Android devices (not available in this environment) — recommend confirming: Critical Alerts actually bypasses DND once permission is granted, the time-sensitive sound name you choose actually plays, and the Android "Critical Medication"/silent channels appear correctly in system settings


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_