### PR TITLE
Repeat overdue reminders until taken/skipped, auto-clear notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Track medications, scheduled doses, streaks, and overdue alerts — entirely loc
 - **Binary sensors** for overdue detection (with configurable grace period) and due-soon alerts (within 60 minutes) for scheduled meds; availability tracking for PRN meds
 - **Button entities** to mark doses as taken or skipped — appear automatically on the device page
 - **Optional stock tracking** — record a current stock level per medication and it's automatically decremented each time a dose is taken, with a low-stock sensor and alert so you never run out
-- **Built-in notifications** — configure overdue, due soon, taken confirmation, and low stock alerts directly from the integration, with actionable notifications (Mark taken / Remind in 5 min) on iOS and Android
+- **Built-in notifications** — configure due, repeating overdue reminders, due soon, taken confirmation, and low stock alerts directly from the integration, with an actionable **Mark taken** button on iOS and Android that also auto-clears any pending reminder
 - **Per-medication notification overrides** — enable or disable individual alert types per medication, overriding the global settings
 - **Services** to mark doses taken or skipped, reset today's log, and adjust stock (e.g. after a refill)
 - **Full UI configuration** — add, edit, and remove medications via the Home Assistant UI (no YAML required)
@@ -110,14 +110,15 @@ Click **Configure** on the integration card, then choose **Notifications** to se
 | Setting | Description |
 |---------|-------------|
 | Notify service | The HA notify service to use (e.g. `notify.mobile_app_your_phone`) — select from the dropdown of detected devices |
-| Alert when due | Send a notification when a dose is due |
-| Alert when overdue | Send a notification when a dose is past its grace period |
-| Overdue delay | Extra minutes to wait after the grace period before notifying (0 = immediate) |
-| Alert when due soon | Send a notification when a dose is due within 60 minutes |
+| Alert when due | Send a notification once, right at the scheduled time |
+| Repeat reminder every N minutes until taken or skipped | Once a dose goes overdue (30 minutes past due by default), keep re-notifying every N minutes until you mark it taken or skipped |
+| Repeat every (minutes) | How often the overdue reminder repeats (default 30) |
+| Stop repeating after this many reminders | Caps how many times it repeats before giving up (default 5) — the overdue state itself doesn't clear, it just stops notifying |
+| Alert when due soon | Send a notification once, when a dose is due within 60 minutes |
 | Taken confirmation | Send a notification when a dose is marked as taken |
 | Alert when stock is low | Send a notification when a medication's stock falls to or below its configured threshold (applies to both scheduled and as-needed medications; requires [stock tracking](#stock-tracking-optional) to be enabled for that medication) |
 
-Notifications on iOS and Android include **Mark taken** and **Remind in 5 min** action buttons. Tapping Mark taken updates the sensors immediately without opening the app.
+Notifications on iOS and Android include a **Mark taken** action button — tapping it updates the sensors immediately without opening the app. Marking a dose taken or skipped from *anywhere* (button, dashboard, service call, or the notification action) automatically clears any pending due/overdue reminder still sitting on your phone, so you're not left with a stale "have you taken this?" notification after you've already dealt with it.
 
 The low stock alert fires once when stock crosses the threshold and won't repeat until you restock above it (via the `adjust_stock` service) and it drops low again.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Click **Configure** on the integration card, then choose **Notifications** to se
 
 Notifications on iOS and Android include a **Mark taken** action button — tapping it updates the sensors immediately without opening the app. Marking a dose taken or skipped from *anywhere* (button, dashboard, service call, or the notification action) automatically clears any pending due/overdue reminder still sitting on your phone, so you're not left with a stale "have you taken this?" notification after you've already dealt with it.
 
+**Android note:** clearing a notification in the background is a known-unreliable operation on Android unless it's delivered with high priority — this integration always requests high-priority delivery for the clear itself, but if it's still not clearing reliably for you, check that battery optimization is disabled for the Home Assistant app (Settings → Apps → Home Assistant → Battery → Unrestricted) and consider setting that alert type's Android sound (in [Notifications](#notifications)) to **Critical**, which is the most reliable delivery path on Android.
+
 The low stock alert fires once when stock crosses the threshold and won't repeat until you restock above it (via the `adjust_stock` service) and it drops low again.
 
 After the global settings, you can also customise the notification title and message templates for each alert type — and, alongside each template, a **Notification Sounds** section with separate iOS and Android options (they control sound differently, so each platform has its own settings). Everything defaults to **Default** — today's plain device notification tone — until you actively change it, so upgrading changes nothing until you visit this screen.
@@ -138,7 +140,7 @@ After the global settings, you can also customise the notification title and mes
 | Option | Behavior |
 |--------|----------|
 | Default | The device's normal notification sound (unchanged from today) |
-| Critical | Routes to a dedicated **Critical Medication** notification channel, with an Importance you choose (Min/Low/Default/High/Max) |
+| Critical | Routes to a dedicated **Critical Medication** notification channel (with an Importance you choose: Min/Low/Default/High/Max) and requests high-priority FCM delivery, the most reliable way to get through Android's background/battery restrictions |
 | No sound | Routes to a dedicated silent channel |
 
 Android sound isn't controllable per-notification — it's tied to the notification *channel*, and Android locks a channel's sound/importance the first time it's created. If you need to change it later, do so in your phone's own notification settings (Settings → Apps → Home Assistant → Notifications → the relevant channel), not from this integration.

--- a/custom_components/medication_tracker/config_flow.py
+++ b/custom_components/medication_tracker/config_flow.py
@@ -33,9 +33,10 @@ from .const import (
     CONF_NOTIF_LOW_STOCK_ENABLED,
     CONF_NOTIF_LOW_STOCK_MESSAGE,
     CONF_NOTIF_LOW_STOCK_TITLE,
-    CONF_NOTIF_OVERDUE_DELAY,
     CONF_NOTIF_OVERDUE_ENABLED,
+    CONF_NOTIF_OVERDUE_MAX_REPEATS,
     CONF_NOTIF_OVERDUE_MESSAGE,
+    CONF_NOTIF_OVERDUE_REPEAT_MINUTES,
     CONF_NOTIF_OVERDUE_TITLE,
     CONF_NOTIF_OVERRIDE_DUE,
     CONF_NOTIF_OVERRIDE_DUE_SOON,
@@ -64,8 +65,9 @@ from .const import (
     DEFAULT_LOW_STOCK_MESSAGE,
     DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
-    DEFAULT_OVERDUE_DELAY,
+    DEFAULT_OVERDUE_MAX_REPEATS,
     DEFAULT_OVERDUE_MESSAGE,
+    DEFAULT_OVERDUE_REPEAT_MINUTES,
     DEFAULT_OVERDUE_TITLE,
     DEFAULT_STOCK_LOW_THRESHOLD,
     DEFAULT_STOCK_PER_DOSE,
@@ -697,9 +699,17 @@ class MedicationOptionsFlow(OptionsFlow):
                         default=cfg.get(CONF_NOTIF_OVERDUE_ENABLED, False),
                     ): bool,
                     vol.Optional(
-                        CONF_NOTIF_OVERDUE_DELAY,
-                        default=cfg.get(CONF_NOTIF_OVERDUE_DELAY, DEFAULT_OVERDUE_DELAY),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=120)),
+                        CONF_NOTIF_OVERDUE_REPEAT_MINUTES,
+                        default=cfg.get(
+                            CONF_NOTIF_OVERDUE_REPEAT_MINUTES, DEFAULT_OVERDUE_REPEAT_MINUTES
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+                    vol.Optional(
+                        CONF_NOTIF_OVERDUE_MAX_REPEATS,
+                        default=cfg.get(
+                            CONF_NOTIF_OVERDUE_MAX_REPEATS, DEFAULT_OVERDUE_MAX_REPEATS
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
                     vol.Optional(
                         CONF_NOTIF_DUE_SOON_ENABLED,
                         default=cfg.get(CONF_NOTIF_DUE_SOON_ENABLED, False),
@@ -1053,9 +1063,13 @@ def _notification_config_from_input(
         CONF_NOTIF_OVERDUE_ENABLED: user_input.get(
             CONF_NOTIF_OVERDUE_ENABLED, existing.get(CONF_NOTIF_OVERDUE_ENABLED, False)
         ),
-        CONF_NOTIF_OVERDUE_DELAY: user_input.get(
-            CONF_NOTIF_OVERDUE_DELAY,
-            existing.get(CONF_NOTIF_OVERDUE_DELAY, DEFAULT_OVERDUE_DELAY),
+        CONF_NOTIF_OVERDUE_REPEAT_MINUTES: user_input.get(
+            CONF_NOTIF_OVERDUE_REPEAT_MINUTES,
+            existing.get(CONF_NOTIF_OVERDUE_REPEAT_MINUTES, DEFAULT_OVERDUE_REPEAT_MINUTES),
+        ),
+        CONF_NOTIF_OVERDUE_MAX_REPEATS: user_input.get(
+            CONF_NOTIF_OVERDUE_MAX_REPEATS,
+            existing.get(CONF_NOTIF_OVERDUE_MAX_REPEATS, DEFAULT_OVERDUE_MAX_REPEATS),
         ),
         CONF_NOTIF_DUE_SOON_ENABLED: user_input.get(
             CONF_NOTIF_DUE_SOON_ENABLED, existing.get(CONF_NOTIF_DUE_SOON_ENABLED, False)

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -92,10 +92,19 @@ DEFAULT_AS_NEEDED_MIN_HOURS = 4
 # Top-level notification config stored in coordinator
 CONF_NOTIFICATIONS = "notifications"
 
+# Tag used on due/due-soon/overdue push notifications so a repeat replaces
+# (rather than stacks on top of) the previous one, and so marking a dose
+# taken or skipped can explicitly clear any pending reminder on the device.
+REMINDER_NOTIFICATION_TAG_PREFIX = "medication_reminder_"
+
 # Global defaults keys
 CONF_NOTIF_TARGET = "notify_target"
+# "Repeat reminder until taken or skipped" — reuses the pre-existing enabled
+# key so anyone who already had "Alert when overdue" on keeps working
+# unchanged after upgrading, just with repeat behavior instead of one-shot.
 CONF_NOTIF_OVERDUE_ENABLED = "overdue_enabled"
-CONF_NOTIF_OVERDUE_DELAY = "overdue_delay_minutes"
+CONF_NOTIF_OVERDUE_REPEAT_MINUTES = "overdue_repeat_minutes"
+CONF_NOTIF_OVERDUE_MAX_REPEATS = "overdue_max_repeats"
 CONF_NOTIF_OVERDUE_TITLE = "overdue_title"
 CONF_NOTIF_OVERDUE_MESSAGE = "overdue_message"
 CONF_NOTIF_DUE_SOON_ENABLED = "due_soon_enabled"
@@ -233,7 +242,8 @@ CONF_NOTIF_OVERRIDE_LOW_STOCK = "override_low_stock"
 
 # Default notify target
 DEFAULT_NOTIFY_TARGET = "notify.persistent_notification"
-DEFAULT_OVERDUE_DELAY = 0
+DEFAULT_OVERDUE_REPEAT_MINUTES = 30
+DEFAULT_OVERDUE_MAX_REPEATS = 5
 
 # Default message templates
 # Available placeholders: {medication}, {dose}, {time}, {overdue_since}

--- a/custom_components/medication_tracker/coordinator.py
+++ b/custom_components/medication_tracker/coordinator.py
@@ -323,6 +323,13 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._dose_log.setdefault(med_id, []).append(entry)
         await self._async_save()
         await self.async_refresh()
+
+        if self._notifier is not None:
+            try:
+                await self._notifier.async_notify_skipped(med_id)
+            except Exception as err:
+                _LOGGER.error("Skipped notification cleanup failed: %s", err)
+
         return True
 
     async def async_reset_today(self, med_id: str) -> bool:

--- a/custom_components/medication_tracker/notify.py
+++ b/custom_components/medication_tracker/notify.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.event import async_call_later
+import homeassistant.util.dt as dt_util
 
 from .const import (
     ANDROID_CRITICAL_CHANNEL,
@@ -24,9 +24,10 @@ from .const import (
     CONF_NOTIF_LOW_STOCK_ENABLED,
     CONF_NOTIF_LOW_STOCK_MESSAGE,
     CONF_NOTIF_LOW_STOCK_TITLE,
-    CONF_NOTIF_OVERDUE_DELAY,
     CONF_NOTIF_OVERDUE_ENABLED,
+    CONF_NOTIF_OVERDUE_MAX_REPEATS,
     CONF_NOTIF_OVERDUE_MESSAGE,
+    CONF_NOTIF_OVERDUE_REPEAT_MINUTES,
     CONF_NOTIF_OVERDUE_TITLE,
     CONF_NOTIF_OVERRIDE_DUE,
     CONF_NOTIF_OVERRIDE_DUE_SOON,
@@ -49,13 +50,15 @@ from .const import (
     DEFAULT_LOW_STOCK_MESSAGE,
     DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
-    DEFAULT_OVERDUE_DELAY,
+    DEFAULT_OVERDUE_MAX_REPEATS,
     DEFAULT_OVERDUE_MESSAGE,
+    DEFAULT_OVERDUE_REPEAT_MINUTES,
     DEFAULT_OVERDUE_TITLE,
     DEFAULT_TAKEN_MESSAGE,
     DEFAULT_TAKEN_TITLE,
     IOS_CRITICAL_SOUND,
     NOTIF_SOUND_KEYS_BY_TYPE,
+    REMINDER_NOTIFICATION_TAG_PREFIX,
     SOUND_MODE_CRITICAL,
     SOUND_MODE_NONE,
     SOUND_MODE_TIME_SENSITIVE,
@@ -69,7 +72,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 ACTION_MARK_TAKEN_PREFIX = "MT_TAKEN_"
-ACTION_REMIND_PREFIX = "MT_REMIND_"
 
 
 def _is_ios(hass: HomeAssistant, target: str) -> bool:
@@ -96,16 +98,20 @@ def _build_action_data(is_ios: bool, med_id: str) -> dict[str, Any]:
     # Encode med_id in the action identifier so it comes back in the event response
     actions = [
         {"action": f"{ACTION_MARK_TAKEN_PREFIX}{med_id}", "title": "Mark taken"},
-        {"action": f"{ACTION_REMIND_PREFIX}{med_id}", "title": "Remind in 5 min"},
     ]
+    # Same tag on both platforms: reusing it means a repeat reminder replaces
+    # the previous one instead of stacking, and it lets async_clear_pending_
+    # reminder() explicitly dismiss it once the dose is taken or skipped.
+    tag = f"{REMINDER_NOTIFICATION_TAG_PREFIX}{med_id}"
     if is_ios:
         return {
             "actions": actions,
             "push": {"category": "MEDICATION_ALERT"},
+            "tag": tag,
         }
     return {
         "actions": actions,
-        "tag": f"medication_{med_id}",
+        "tag": tag,
         "persistent": False,
     }
 
@@ -161,8 +167,13 @@ class MedicationNotifier:
         # cleared when stock rises back above the threshold — not by the
         # daily reset below, which would otherwise re-fire it every midnight.
         self._low_stock_fired: set[str] = set()
+        # Overdue repeat tracking: when each medication's reminder last fired,
+        # and how many times, so it can repeat every N minutes up to a max
+        # instead of firing once. Reset whenever the medication stops being
+        # overdue (taken/skipped, or the next scheduled dose rolls around).
+        self._overdue_last_fired: dict[str, datetime] = {}
+        self._overdue_repeat_count: dict[str, int] = {}
         self._unsub_action: Any = None
-        self._reminder_unsubs: list[Any] = []
         self._register_action_listener()
 
     # ------------------------------------------------------------------
@@ -174,80 +185,58 @@ class MedicationNotifier:
         @callback
         def _handle_action(event: Any) -> None:
             action = event.data.get("action", "")
-            # Extract med_id from the action identifier prefix
-            med_id = None
-            is_taken = False
-            is_remind = False
-            if action.startswith(ACTION_MARK_TAKEN_PREFIX):
-                med_id = action[len(ACTION_MARK_TAKEN_PREFIX):]
-                is_taken = True
-            elif action.startswith(ACTION_REMIND_PREFIX):
-                med_id = action[len(ACTION_REMIND_PREFIX):]
-                is_remind = True
-            else:
+            if not action.startswith(ACTION_MARK_TAKEN_PREFIX):
                 return
-
+            med_id = action[len(ACTION_MARK_TAKEN_PREFIX):]
             if not med_id:
                 return
 
             _LOGGER.debug("Notification action %s received for med %s", action, med_id)
 
-            if is_taken:
-                state = self._coordinator.get_med_state(med_id)
-                self._hass.async_create_task(
-                    self._coordinator.async_mark_taken(
-                        med_id, scheduled_time=extract_scheduled_time(state)
-                    )
+            state = self._coordinator.get_med_state(med_id)
+            self._hass.async_create_task(
+                self._coordinator.async_mark_taken(
+                    med_id, scheduled_time=extract_scheduled_time(state)
                 )
-            elif is_remind:
-                self._schedule_reminder(med_id)
+            )
 
         self._unsub_action = self._hass.bus.async_listen(
             "mobile_app_notification_action", _handle_action
         )
 
-    def _schedule_reminder(self, med_id: str) -> None:
-        """Fire a reminder notification for med_id after 5 minutes."""
-        @callback
-        def _send_reminder(_now: Any) -> None:
-            med = self._coordinator.get_medication(med_id)
-            if not med:
-                return
-            state = self._coordinator.get_med_state(med_id)
-            # Skip if the dose was already handled while the reminder was pending
-            if not (state.get("is_overdue") or state.get("is_due_now") or state.get("is_due_soon")):
-                return
-            notif_config = self._coordinator.notification_config
-            title = notif_config.get(CONF_NOTIF_OVERDUE_TITLE, DEFAULT_OVERDUE_TITLE)
-            message = notif_config.get(CONF_NOTIF_OVERDUE_MESSAGE, DEFAULT_OVERDUE_MESSAGE)
-            self._hass.async_create_task(
-                self._send(
-                    notif_config,
-                    title,
-                    message,
-                    {
-                        "medication": med["name"],
-                        "dose": med.get("dose", ""),
-                        "time": state.get("next_dose_time", ""),
-                        "overdue_since": _format_time(state.get("overdue_since", "")),
-                    },
-                    med_id=med_id,
-                    actionable=True,
-                    sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["overdue"],
-                )
-            )
-
-        _LOGGER.debug("Scheduling reminder for med %s in 5 minutes", med_id)
-        self._reminder_unsubs.append(async_call_later(self._hass, 300, _send_reminder))
-
     def unsubscribe(self) -> None:
-        """Clean up the event listener and any pending reminder timers on unload."""
+        """Clean up the event listener on unload."""
         if self._unsub_action is not None:
             self._unsub_action()
             self._unsub_action = None
-        for cancel in self._reminder_unsubs:
-            cancel()
-        self._reminder_unsubs.clear()
+
+    async def async_clear_pending_reminder(self, med_id: str) -> None:
+        """Dismiss any pending due/due-soon/overdue notification for med_id.
+
+        Called whenever a dose is marked taken or skipped, regardless of
+        source, so a reminder doesn't keep sitting on the device once it's
+        no longer relevant.
+        """
+        notif_config = self._coordinator.notification_config
+        target = notif_config.get(CONF_NOTIF_TARGET, DEFAULT_NOTIFY_TARGET)
+        if target == DEFAULT_NOTIFY_TARGET:
+            return
+        parts = target.split(".", 1)
+        if len(parts) != 2:
+            return
+        domain, service = parts[0], parts[1]
+        try:
+            await self._hass.services.async_call(
+                domain,
+                service,
+                {
+                    "message": "clear_notification",
+                    "data": {"tag": f"{REMINDER_NOTIFICATION_TAG_PREFIX}{med_id}"},
+                },
+                blocking=False,
+            )
+        except Exception as err:
+            _LOGGER.error("Failed to clear pending reminder via %s: %s", target, err)
 
     # ------------------------------------------------------------------
     # Public entry points
@@ -274,6 +263,10 @@ class MedicationNotifier:
     async def async_notify_taken(self, med_id: str) -> None:
         """Called immediately when a dose is marked taken."""
         self._reset_if_new_day()
+        self._overdue_last_fired.pop(med_id, None)
+        self._overdue_repeat_count.pop(med_id, None)
+        await self.async_clear_pending_reminder(med_id)
+
         notif_config = self._coordinator.notification_config
         med = self._coordinator.get_medication(med_id)
         if not med:
@@ -304,6 +297,12 @@ class MedicationNotifier:
             actionable=False,
             sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["taken"],
         )
+
+    async def async_notify_skipped(self, med_id: str) -> None:
+        """Called immediately when a dose is marked skipped."""
+        self._overdue_last_fired.pop(med_id, None)
+        self._overdue_repeat_count.pop(med_id, None)
+        await self.async_clear_pending_reminder(med_id)
 
     # ------------------------------------------------------------------
     # Internal checkers
@@ -359,7 +358,12 @@ class MedicationNotifier:
         notif_config: dict[str, Any],
         overrides: dict[str, Any],
     ) -> None:
+        med_id = med["id"]
         if not state.get("is_overdue"):
+            # No longer overdue (taken/skipped, or the next scheduled dose
+            # rolled around) — reset so the next overdue period starts fresh.
+            self._overdue_last_fired.pop(med_id, None)
+            self._overdue_repeat_count.pop(med_id, None)
             return
 
         enabled = overrides.get(
@@ -367,31 +371,29 @@ class MedicationNotifier:
             notif_config.get(CONF_NOTIF_OVERDUE_ENABLED, False),
         )
         if not enabled:
-            _LOGGER.debug("Overdue notification disabled for %s", med["name"])
+            _LOGGER.debug("Overdue reminder disabled for %s", med["name"])
             return
 
-        overdue_since = state.get("overdue_since", "")
-        fire_key = f"{med['id']}_overdue_{overdue_since}"
-        if fire_key in self._fired:
-            _LOGGER.debug("Overdue notification already fired for %s", med["name"])
+        max_repeats = notif_config.get(
+            CONF_NOTIF_OVERDUE_MAX_REPEATS, DEFAULT_OVERDUE_MAX_REPEATS
+        )
+        repeat_count = self._overdue_repeat_count.get(med_id, 0)
+        if repeat_count >= max_repeats:
             return
 
-        delay = notif_config.get(CONF_NOTIF_OVERDUE_DELAY, DEFAULT_OVERDUE_DELAY)
-        if delay and delay > 0 and overdue_since:
-            try:
-                overdue_dt = datetime.fromisoformat(overdue_since)
-                from homeassistant.util.dt import now as ha_now
-                elapsed = (ha_now() - overdue_dt).total_seconds() / 60
-                if elapsed < delay:
-                    _LOGGER.debug(
-                        "Overdue delay not met for %s (%.1f / %d min)",
-                        med["name"], elapsed, delay,
-                    )
-                    return
-            except ValueError:
-                pass
+        now = dt_util.now()
+        last_fired = self._overdue_last_fired.get(med_id)
+        if last_fired is not None:
+            repeat_minutes = notif_config.get(
+                CONF_NOTIF_OVERDUE_REPEAT_MINUTES, DEFAULT_OVERDUE_REPEAT_MINUTES
+            )
+            elapsed_minutes = (now - last_fired).total_seconds() / 60
+            if elapsed_minutes < repeat_minutes:
+                return
 
-        _LOGGER.debug("Firing overdue notification for %s", med["name"])
+        _LOGGER.debug(
+            "Firing overdue reminder %d/%d for %s", repeat_count + 1, max_repeats, med["name"]
+        )
         title = notif_config.get(CONF_NOTIF_OVERDUE_TITLE, DEFAULT_OVERDUE_TITLE)
         message = notif_config.get(CONF_NOTIF_OVERDUE_MESSAGE, DEFAULT_OVERDUE_MESSAGE)
         await self._send(
@@ -402,13 +404,14 @@ class MedicationNotifier:
                 "medication": med["name"],
                 "dose": med.get("dose", ""),
                 "time": state.get("next_dose_time", ""),
-                "overdue_since": _format_time(overdue_since),
+                "overdue_since": _format_time(state.get("overdue_since", "")),
             },
-            med_id=med["id"],
+            med_id=med_id,
             actionable=True,
             sound_keys=NOTIF_SOUND_KEYS_BY_TYPE["overdue"],
         )
-        self._fired.add(fire_key)
+        self._overdue_last_fired[med_id] = now
+        self._overdue_repeat_count[med_id] = repeat_count + 1
 
     async def _check_due_soon(
         self,

--- a/custom_components/medication_tracker/notify.py
+++ b/custom_components/medication_tracker/notify.py
@@ -148,6 +148,11 @@ def _apply_sound(
             importance = notif_config.get(android_importance_key, DEFAULT_ANDROID_IMPORTANCE)
             data["channel"] = ANDROID_CRITICAL_CHANNEL
             data["importance"] = importance
+            # Channel/importance only control on-screen behavior once the
+            # notification arrives — reliably bypassing background/Doze
+            # restrictions also needs FCM high-priority delivery.
+            data["priority"] = "high"
+            data["ttl"] = 0
         elif mode == SOUND_MODE_NONE:
             data["channel"] = ANDROID_SILENT_CHANNEL
             data["importance"] = ANDROID_SILENT_IMPORTANCE
@@ -231,7 +236,16 @@ class MedicationNotifier:
                 service,
                 {
                     "message": "clear_notification",
-                    "data": {"tag": f"{REMINDER_NOTIFICATION_TAG_PREFIX}{med_id}"},
+                    "data": {
+                        "tag": f"{REMINDER_NOTIFICATION_TAG_PREFIX}{med_id}",
+                        # Android defers/drops normal-priority background push
+                        # unless the app was recently active — clear commands
+                        # need FCM high-priority delivery (like Android's own
+                        # critical notifications use) to land reliably. No
+                        # effect on iOS, which ignores these fields.
+                        "priority": "high",
+                        "ttl": 0,
+                    },
                 },
                 blocking=False,
             )

--- a/custom_components/medication_tracker/strings.json
+++ b/custom_components/medication_tracker/strings.json
@@ -52,8 +52,9 @@
         "data": {
           "notify_target": "Notify service (e.g. notify.persistent_notification)",
           "due_enabled": "Alert when a dose is due",
-          "overdue_enabled": "Alert when a dose is overdue",
-          "overdue_delay_minutes": "Overdue alert delay (minutes after grace period, 0 = immediate)",
+          "overdue_enabled": "Repeat reminder every N minutes until taken or skipped",
+          "overdue_repeat_minutes": "Repeat every (minutes)",
+          "overdue_max_repeats": "Stop repeating after this many reminders",
           "due_soon_enabled": "Alert when a dose is due soon",
           "taken_enabled": "Confirm when a dose is marked taken",
           "low_stock_enabled": "Alert when stock is running low",

--- a/custom_components/medication_tracker/translations/en.json
+++ b/custom_components/medication_tracker/translations/en.json
@@ -52,8 +52,9 @@
         "data": {
           "notify_target": "Notify service (e.g. notify.persistent_notification)",
           "due_enabled": "Alert when a dose is due",
-          "overdue_enabled": "Alert when a dose is overdue",
-          "overdue_delay_minutes": "Overdue alert delay (minutes after grace period, 0 = immediate)",
+          "overdue_enabled": "Repeat reminder every N minutes until taken or skipped",
+          "overdue_repeat_minutes": "Repeat every (minutes)",
+          "overdue_max_repeats": "Stop repeating after this many reminders",
           "due_soon_enabled": "Alert when a dose is due soon",
           "taken_enabled": "Confirm when a dose is marked taken",
           "low_stock_enabled": "Alert when stock is running low",


### PR DESCRIPTION
## Summary
Stacked on #11 (Notification Sounds) since both touch the same core `notify.py` send path — base this PR against that branch rather than `main` for now; it'll retarget to `main` automatically once #11 merges.

Two related fixes to notification timing/behavior, from a conversation about the confusing wording and missing auto-dismiss:

**1. Repeating overdue reminders**
- Replaces the one-shot "Alert when overdue" + manual "Remind in 5 min" button with an automatic repeat: once a dose goes overdue, it re-notifies every N minutes (default 30, user-configurable) up to a max number of repeats (default 5, user-configurable), then stops.
- Reuses the pre-existing `overdue_enabled` config key, so anyone with it already on keeps working unmodified after upgrading — new behavior (repeat instead of once) applies automatically, no migration needed.
- Removes the "Overdue delay" field — the first repeat now fires right when the dose becomes overdue (30 min grace period, unchanged).
- Implementation reuses the existing once-a-minute state tick (no new timers) — tracks last-fired time + repeat count per medication, resetting whenever the medication stops being overdue (taken, skipped, or the next scheduled dose rolls around).
- Removes "Remind in 5 min" entirely (redundant with automatic repeating, and having both would reintroduce the exact confusion this is meant to fix).

**2. Auto-clear on taken/skipped**
- Marking a dose taken or skipped (dashboard, service call, notification action — anywhere) now sends an explicit `clear_notification` call, so a pending due/overdue reminder doesn't sit on your phone after you've already dealt with it.
- Fixed a related gap this needed: iOS notifications weren't getting a `tag` set at all (only Android was), so clearing couldn't target them. Both platforms now share one consistent tag per medication.

## Test plan
- [x] `ruff check custom_components/` — passes
- [x] `flake8 custom_components/medication_tracker/ --max-line-length=120 --ignore=E501,W503` (Python 3.12, matching CI) — passes
- [x] `python3.12 -m py_compile` on all changed files — passes
- [x] `strings.json` / `translations/en.json` validated as valid JSON, byte-identical, no leftover references to removed config keys
- [x] Independent adversarial review: confirmed first-fire is immediate (not delayed by the repeat interval), repeat/max-repeat state correctly resets between separate overdue episodes for the same medication, the clear call safely no-ops for the default `persistent_notification` target, and grepped the whole component for dead references to every removed constant/import — zero hits
- [ ] Manual verification on a real device (not available in this environment) — recommend confirming a repeat reminder actually fires on schedule, stops at the configured max, and that marking taken from the dashboard actually dismisses the phone notification

**Known pre-existing limitation** (not introduced or regressed by this PR, surfaced during review): if a medication has multiple doses per day, the coordinator only tracks the *earliest* unresolved dose as "overdue" at a time — so if dose 1 is ignored past its max repeats, dose 2 later that day won't get its own reminders until dose 1 is resolved. Flagging for visibility; happy to take that on separately if it's worth fixing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_