### PR TITLE
Render overdue repeat fields as number boxes, not sliders

### DIFF
--- a/custom_components/medication_tracker/config_flow.py
+++ b/custom_components/medication_tracker/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
+from homeassistant.helpers.selector import NumberSelector, NumberSelectorConfig, NumberSelectorMode
 
 from .const import (
     ANDROID_IMPORTANCE_OPTIONS,
@@ -703,13 +704,23 @@ class MedicationOptionsFlow(OptionsFlow):
                         default=cfg.get(
                             CONF_NOTIF_OVERDUE_REPEAT_MINUTES, DEFAULT_OVERDUE_REPEAT_MINUTES
                         ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+                    ): vol.All(
+                        NumberSelector(
+                            NumberSelectorConfig(min=1, max=1440, step=1, mode=NumberSelectorMode.BOX)
+                        ),
+                        vol.Coerce(int),
+                    ),
                     vol.Optional(
                         CONF_NOTIF_OVERDUE_MAX_REPEATS,
                         default=cfg.get(
                             CONF_NOTIF_OVERDUE_MAX_REPEATS, DEFAULT_OVERDUE_MAX_REPEATS
                         ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
+                    ): vol.All(
+                        NumberSelector(
+                            NumberSelectorConfig(min=1, max=100, step=1, mode=NumberSelectorMode.BOX)
+                        ),
+                        vol.Coerce(int),
+                    ),
                     vol.Optional(
                         CONF_NOTIF_DUE_SOON_ENABLED,
                         default=cfg.get(CONF_NOTIF_DUE_SOON_ENABLED, False),


### PR DESCRIPTION
## Summary
Small follow-up to #12 (merged) — that PR's `overdue_max_repeats` field was rendering as a slider in the Notifications form, inconsistent with `overdue_repeat_minutes` next to it, which rendered as a plain number box. This was raised after #12 had already merged, so it landed as an orphaned commit on that branch and needed a fresh PR off `main`.

Both fields now use an explicit `NumberSelector` in box mode with step arrows, so they look and behave the same regardless of their range size.

## Test plan
- [x] `ruff check custom_components/` — passes
- [x] `flake8 custom_components/medication_tracker/ --max-line-length=120 --ignore=E501,W503` (Python 3.12, matching CI) — passes
- [x] `python3.12 -m py_compile` — passes
- [ ] Manual verification in a running Home Assistant instance (not available in this environment) — recommend confirming both fields render as number boxes with up/down arrows in the Notifications config screen


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_