### PR TITLE
docs: add download count and workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/default)
 [![GitHub release](https://img.shields.io/github/release/calebgab/medication_tracker.svg)](https://github.com/calebgab/medication_tracker/releases)
+[![Downloads (latest release)](https://img.shields.io/github/downloads/calebgab/medication_tracker/latest/total.svg)](https://github.com/calebgab/medication_tracker/releases/latest)
+[![Downloads (all releases)](https://img.shields.io/github/downloads/calebgab/medication_tracker/total.svg)](https://github.com/calebgab/medication_tracker/releases)
 [![CI](https://github.com/calebgab/medication_tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/calebgab/medication_tracker/actions/workflows/ci.yml)
+[![Validate](https://github.com/calebgab/medication_tracker/actions/workflows/validate.yml/badge.svg)](https://github.com/calebgab/medication_tracker/actions/workflows/validate.yml)
+[![Validate Custom](https://github.com/calebgab/medication_tracker/actions/workflows/validate-custom.yml/badge.svg)](https://github.com/calebgab/medication_tracker/actions/workflows/validate-custom.yml)
+[![Validate with hassfest](https://github.com/calebgab/medication_tracker/actions/workflows/hassfest.yaml/badge.svg)](https://github.com/calebgab/medication_tracker/actions/workflows/hassfest.yaml)
 
 Track medications, scheduled doses, streaks, and overdue alerts — entirely local, no cloud, no app required.
 


### PR DESCRIPTION
## Summary
- Adds two GitHub download-count badges: latest release downloads and all-time total downloads (shields.io `github/downloads`)
- Adds status badges for the other CI workflows already running on this repo, alongside the existing CI badge: `validate.yml` (HACS validation), `validate-custom.yml` (manifest/lint checks), `hassfest.yaml` (hassfest validation)

## Test plan
- [x] Visual check of badge markdown syntax and linked URLs against the actual workflow filenames in `.github/workflows/`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_