### PR TITLE
Make overdue grace period configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ Click **Configure** on the integration card, then choose **Notifications** to se
 |---------|-------------|
 | Notify service | The HA notify service to use (e.g. `notify.mobile_app_your_phone`) — select from the dropdown of detected devices |
 | Alert when due | Send a notification once, right at the scheduled time |
-| Repeat reminder every N minutes until taken or skipped | Once a dose goes overdue (30 minutes past due by default), keep re-notifying every N minutes until you mark it taken or skipped |
-| Repeat every (minutes) | How often the overdue reminder repeats (default 30) |
+| Repeat reminder every N minutes until taken or skipped | Once a dose goes overdue, keep re-notifying every N minutes until you mark it taken or skipped |
+| Consider overdue after (minutes) | How long past the scheduled time before a dose is treated as overdue (default 30) — this is a single global setting shared by all medications, so time-sensitive meds can use a short grace period without affecting others |
+| Repeat every (minutes) | How often the overdue reminder repeats once overdue (default 30) |
 | Stop repeating after this many reminders | Caps how many times it repeats before giving up (default 5) — the overdue state itself doesn't clear, it just stops notifying |
 | Alert when due soon | Send a notification once, when a dose is due within 60 minutes |
 | Taken confirmation | Send a notification when a dose is marked as taken |
@@ -344,7 +345,7 @@ tap_action:
 
 ## Overdue Grace Period
 
-A scheduled dose is not considered overdue until **30 minutes** after its scheduled time, to account for slight delays. The due-soon window is **60 minutes** before a scheduled dose.
+A scheduled dose is not considered overdue until the **Consider overdue after (minutes)** setting has elapsed past its scheduled time (default 30, configurable in **Configure → Notifications**) — lower it for medications that need to be taken right on time. The due-soon window is **60 minutes** before a scheduled dose.
 
 ---
 

--- a/custom_components/medication_tracker/config_flow.py
+++ b/custom_components/medication_tracker/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_NOTIF_LOW_STOCK_MESSAGE,
     CONF_NOTIF_LOW_STOCK_TITLE,
     CONF_NOTIF_OVERDUE_ENABLED,
+    CONF_NOTIF_OVERDUE_GRACE_MINUTES,
     CONF_NOTIF_OVERDUE_MAX_REPEATS,
     CONF_NOTIF_OVERDUE_MESSAGE,
     CONF_NOTIF_OVERDUE_REPEAT_MINUTES,
@@ -66,6 +67,7 @@ from .const import (
     DEFAULT_LOW_STOCK_MESSAGE,
     DEFAULT_LOW_STOCK_TITLE,
     DEFAULT_NOTIFY_TARGET,
+    DEFAULT_OVERDUE_GRACE_MINUTES,
     DEFAULT_OVERDUE_MAX_REPEATS,
     DEFAULT_OVERDUE_MESSAGE,
     DEFAULT_OVERDUE_REPEAT_MINUTES,
@@ -700,6 +702,17 @@ class MedicationOptionsFlow(OptionsFlow):
                         default=cfg.get(CONF_NOTIF_OVERDUE_ENABLED, False),
                     ): bool,
                     vol.Optional(
+                        CONF_NOTIF_OVERDUE_GRACE_MINUTES,
+                        default=cfg.get(
+                            CONF_NOTIF_OVERDUE_GRACE_MINUTES, DEFAULT_OVERDUE_GRACE_MINUTES
+                        ),
+                    ): vol.All(
+                        NumberSelector(
+                            NumberSelectorConfig(min=0, max=1440, step=1, mode=NumberSelectorMode.BOX)
+                        ),
+                        vol.Coerce(int),
+                    ),
+                    vol.Optional(
                         CONF_NOTIF_OVERDUE_REPEAT_MINUTES,
                         default=cfg.get(
                             CONF_NOTIF_OVERDUE_REPEAT_MINUTES, DEFAULT_OVERDUE_REPEAT_MINUTES
@@ -1073,6 +1086,10 @@ def _notification_config_from_input(
         ),
         CONF_NOTIF_OVERDUE_ENABLED: user_input.get(
             CONF_NOTIF_OVERDUE_ENABLED, existing.get(CONF_NOTIF_OVERDUE_ENABLED, False)
+        ),
+        CONF_NOTIF_OVERDUE_GRACE_MINUTES: user_input.get(
+            CONF_NOTIF_OVERDUE_GRACE_MINUTES,
+            existing.get(CONF_NOTIF_OVERDUE_GRACE_MINUTES, DEFAULT_OVERDUE_GRACE_MINUTES),
         ),
         CONF_NOTIF_OVERDUE_REPEAT_MINUTES: user_input.get(
             CONF_NOTIF_OVERDUE_REPEAT_MINUTES,

--- a/custom_components/medication_tracker/const.py
+++ b/custom_components/medication_tracker/const.py
@@ -59,8 +59,6 @@ CONF_STOCK_LOW_THRESHOLD = "stock_low_threshold"
 DEFAULT_STOCK_PER_DOSE = 1.0
 DEFAULT_STOCK_LOW_THRESHOLD = 5.0
 
-# How many minutes past a scheduled time before it's considered overdue
-OVERDUE_GRACE_MINUTES = 30
 # How many minutes before a scheduled time to show "due soon"
 DUE_SOON_MINUTES = 60
 
@@ -103,6 +101,7 @@ CONF_NOTIF_TARGET = "notify_target"
 # key so anyone who already had "Alert when overdue" on keeps working
 # unchanged after upgrading, just with repeat behavior instead of one-shot.
 CONF_NOTIF_OVERDUE_ENABLED = "overdue_enabled"
+CONF_NOTIF_OVERDUE_GRACE_MINUTES = "overdue_grace_minutes"
 CONF_NOTIF_OVERDUE_REPEAT_MINUTES = "overdue_repeat_minutes"
 CONF_NOTIF_OVERDUE_MAX_REPEATS = "overdue_max_repeats"
 CONF_NOTIF_OVERDUE_TITLE = "overdue_title"
@@ -242,6 +241,7 @@ CONF_NOTIF_OVERRIDE_LOW_STOCK = "override_low_stock"
 
 # Default notify target
 DEFAULT_NOTIFY_TARGET = "notify.persistent_notification"
+DEFAULT_OVERDUE_GRACE_MINUTES = 30
 DEFAULT_OVERDUE_REPEAT_MINUTES = 30
 DEFAULT_OVERDUE_MAX_REPEATS = 5
 

--- a/custom_components/medication_tracker/coordinator.py
+++ b/custom_components/medication_tracker/coordinator.py
@@ -16,6 +16,7 @@ import homeassistant.util.dt as dt_util
 
 from .const import (
     CONF_CURRENT_STOCK,
+    CONF_NOTIF_OVERDUE_GRACE_MINUTES,
     CONF_NOTIFICATIONS,
     CONF_STOCK_LOW_THRESHOLD,
     CONF_STOCK_PER_DOSE,
@@ -23,13 +24,13 @@ from .const import (
     DEFAULT_AS_NEEDED_MAX_PER_24H,
     DEFAULT_AS_NEEDED_MAX_PER_DAY,
     DEFAULT_AS_NEEDED_MIN_HOURS,
+    DEFAULT_OVERDUE_GRACE_MINUTES,
     DEFAULT_STOCK_LOW_THRESHOLD,
     DEFAULT_STOCK_PER_DOSE,
     DOMAIN,
     DUE_SOON_MINUTES,
     MED_TYPE_AS_NEEDED,
     MED_TYPE_SCHEDULED,
-    OVERDUE_GRACE_MINUTES,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
@@ -427,6 +428,9 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         overdue_since: str | None = None
         is_due_now = False
         due_at_time: str | None = None
+        overdue_grace_minutes = self._notification_config.get(
+            CONF_NOTIF_OVERDUE_GRACE_MINUTES, DEFAULT_OVERDUE_GRACE_MINUTES
+        )
         if scheduled_today:
             for t_str in sorted(scheduled_times):
                 try:
@@ -434,7 +438,7 @@ class MedicationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except ValueError:
                     continue
                 scheduled_dt = datetime.combine(today, t, tzinfo=now.tzinfo)
-                grace_dt = scheduled_dt + timedelta(minutes=OVERDUE_GRACE_MINUTES)
+                grace_dt = scheduled_dt + timedelta(minutes=overdue_grace_minutes)
                 if now > grace_dt:
                     handled = any(e.get("scheduled_time") == t_str for e in today_entries)
                     if not handled:

--- a/custom_components/medication_tracker/strings.json
+++ b/custom_components/medication_tracker/strings.json
@@ -53,6 +53,7 @@
           "notify_target": "Notify service (e.g. notify.persistent_notification)",
           "due_enabled": "Alert when a dose is due",
           "overdue_enabled": "Repeat reminder every N minutes until taken or skipped",
+          "overdue_grace_minutes": "Consider overdue after (minutes)",
           "overdue_repeat_minutes": "Repeat every (minutes)",
           "overdue_max_repeats": "Stop repeating after this many reminders",
           "due_soon_enabled": "Alert when a dose is due soon",

--- a/custom_components/medication_tracker/translations/en.json
+++ b/custom_components/medication_tracker/translations/en.json
@@ -53,6 +53,7 @@
           "notify_target": "Notify service (e.g. notify.persistent_notification)",
           "due_enabled": "Alert when a dose is due",
           "overdue_enabled": "Repeat reminder every N minutes until taken or skipped",
+          "overdue_grace_minutes": "Consider overdue after (minutes)",
           "overdue_repeat_minutes": "Repeat every (minutes)",
           "overdue_max_repeats": "Stop repeating after this many reminders",
           "due_soon_enabled": "Alert when a dose is due soon",


### PR DESCRIPTION
## Summary
- Replace the hardcoded `OVERDUE_GRACE_MINUTES = 30` constant with a global, configurable **"Consider overdue after (minutes)"** setting on the Notifications screen (`Configure → Notifications`), so medications that need to be taken right on time don't have to wait a fixed 30 minutes before the first overdue alert.
- Uses the same `NumberSelector` box (up/down arrows) pattern already used for `overdue_repeat_minutes`/`overdue_max_repeats`.
- Default stays 30 minutes, so existing installs behave exactly as before until the setting is changed.
- Updated README (Notifications table + Overdue Grace Period section) to reflect that the delay is now configurable rather than fixed.

## Test plan
- [x] `python3.12 -m py_compile` on changed files
- [x] `ruff check custom_components/`
- [x] Verified `strings.json` / `translations/en.json` stay byte-identical and both parse as valid JSON
- [x] Verified no remaining references to the removed `OVERDUE_GRACE_MINUTES` constant
- [x] Adversarial review of the diff for correctness (init ordering, edge cases, upgrade path for existing configs)
- [ ] Manual verification in a running HA instance: change the setting, confirm a dose flips to overdue at the new interval instead of 30 minutes


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT5wJnp2E5oA5Nd52cBswx)_